### PR TITLE
Clean up navbar a little

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -3,6 +3,7 @@
 {% load static %}
 <head>
  <title>Compute Studio</title>
+ <link rel="icon" href="{% static 'imgs/cslashs.png' %}" type="image/x-icon">
  <script src="https://code.jquery.com/jquery-3.3.1.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
  <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49" crossorigin="anonymous"></script>
  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
@@ -20,7 +21,7 @@
 
 <body class="main-content">
   <nav class="navbar navbar-custom navbar-expand shadow">
-      <a href="{% url 'home' %}" class="navbar-brand"><img class="mr-2" src="{% static 'imgs/cslashs.png' %}" width="30" height="30" alt="Compute Studio">Compute Studio</a>
+      <a href="{% url 'home' %}" class="navbar-brand"><img class="mr-2" src="{% static 'imgs/cslashs.png' %}" width="30" height="30" alt="Compute Studio"></a>
       <ul class="navbar-nav">
         <li class="nav-item dropdown">
           <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">


### PR DESCRIPTION
Removes Compute Studio from the navbar to make it look a little cleaner, especially on mobile. This PR also adds the C/S logo to the title of the page so that it shows up in the browser tab.