### PR TITLE
Add API endpoint for listing projects

### DIFF
--- a/webapp/apps/publish/tests/test_views.py
+++ b/webapp/apps/publish/tests/test_views.py
@@ -137,3 +137,12 @@ class TestPublishViews:
     def test_get_detail_page(self, client, test_models):
         resp = client.get("/modeler/Used-for-testing/detail/")
         assert resp.status_code == 200
+
+    def test_get_projects(self, client, test_models):
+        resp = client.get("/publish/api/")
+        assert resp.status_code == 200
+
+        exp = set(proj.title for proj in Project.objects.all())
+        act = set(proj["title"] for proj in resp.data)
+
+        assert exp == act

--- a/webapp/apps/publish/urls.py
+++ b/webapp/apps/publish/urls.py
@@ -1,12 +1,7 @@
 from django.conf.urls import url
 from django.urls import path
 
-from .views import (
-    ProjectView,
-    ProjectDetailView,
-    ProjectDetailAPIView,
-    ProjectCreateAPIView,
-)
+from .views import ProjectView, ProjectDetailView, ProjectDetailAPIView, ProjectAPIView
 
 
 urlpatterns = [
@@ -16,5 +11,5 @@ urlpatterns = [
         ProjectDetailAPIView.as_view(),
         name="project_detail_api",
     ),
-    path("api/", ProjectCreateAPIView.as_view(), name="project_create_api"),
+    path("api/", ProjectAPIView.as_view(), name="project_create_api"),
 ]

--- a/webapp/apps/publish/views.py
+++ b/webapp/apps/publish/views.py
@@ -81,7 +81,13 @@ class ProjectDetailAPIView(GetProjectMixin, APIView):
         return Response(status=status.HTTP_401_UNAUTHORIZED)
 
 
-class ProjectCreateAPIView(GetProjectMixin, APIView):
+class ProjectAPIView(GetProjectMixin, APIView):
+    queryset = Project.objects.all()
+
+    def get(self, request, *args, **kwargs):
+        ser = PublishSerializer(self.queryset.all(), many=True)
+        return Response(ser.data, status=status.HTTP_200_OK)
+
     def post(self, request, *args, **kwargs):
         if request.user.is_authenticated:
             serializer = PublishSerializer(data=request.POST)


### PR DESCRIPTION
This will make it possible to build the C/S compute cluster from the information that is stored in the C/S database. Currently, all of the build config is stored in a JSON file that I keep locally. This file mirrors information like the project owner, title, and GitHub url that is already stored in the C/S database. In the coming weeks, I plan to:

- Update the resource specification fields so that they ailgn with the memory/cpu options in the kubernetes config files.
- A field for specifying the target branch that a project should be built from.
- Add a button publishers can hit to trigger a build and deploy.
  - For now, this will just ping me with an email, but in the future, this will automatically trigger a build for verified publishers.