### PR TITLE
Fix create API permissions

### DIFF
--- a/webapp/apps/comp/permissions.py
+++ b/webapp/apps/comp/permissions.py
@@ -3,7 +3,11 @@ from rest_framework.permissions import BasePermission, SAFE_METHODS
 
 class RequiresActive(BasePermission):
     def has_permission(self, request, view):
-        return bool(request.user.profile and request.user.profile.is_active)
+        return bool(
+            request.user.is_authenticated
+            and request.user.profile
+            and request.user.profile.is_active
+        )
 
 
 class RequiresPayment(BasePermission):

--- a/webapp/apps/comp/tests/test_asyncviews.py
+++ b/webapp/apps/comp/tests/test_asyncviews.py
@@ -414,3 +414,11 @@ def test_outputs_api(db, api_client, profile, password):
         api_client.put("/outputs/api/", data={"bad": "data"}, format="json").status_code
         == 400
     )
+
+
+def test_anon_get_create_api(db, api_client):
+    anon_user = auth.get_user(api_client)
+    assert not anon_user.is_authenticated
+
+    resp = api_client.get("/hdoupe/Matchups/api/v1/")
+    assert resp.status_code == 403


### PR DESCRIPTION
This PR fixes a bug where anonymous users got a 500 error instead of a 403 forbidden error when they did an unauthenticated request to the create sim REST API. This bug is resolved by checking if the user is authenticated before checking whether they have a profile.