### PR TITLE
Inrease polling interval from 1 sec to 5 secs

### DIFF
--- a/templates/comp/not_ready.html
+++ b/templates/comp/not_ready.html
@@ -48,13 +48,13 @@
             insertEta(data.eta, data.origEta);
             setTimeout(function() {
               window.location.reload(1);
-            }, 7000);
+            }, 1000);
           }
         }
       });
     }
     ajaxEta();
-    setInterval(ajaxEta, 1000);
+    setInterval(ajaxEta, 5000);
   });
 </script>
 {% endblock %}


### PR DESCRIPTION
This increases the interval for the requests that poll whether a job has completed. This ought to reduce the load on the servers from extraneous requests.