### PR TITLE
Give the run_model task the job_id for its distributed key

### DIFF
--- a/distributed/api/endpoints.py
+++ b/distributed/api/endpoints.py
@@ -107,8 +107,8 @@ def dask_endpoint(owner, app_name, action):
     # Worker needs the job_id to push the results back to the
     # webapp.
     # The url and api token are passed as args insted of env
-    # variables because the model doesn't need to have
-    # access to them.
+    # variables so that the wrapper has access to them
+    # but the model does not.
     inputs.update(
         {
             "job_id": job_id,
@@ -119,9 +119,9 @@ def dask_endpoint(owner, app_name, action):
     )
 
     with Client(addr) as c:
-        fut = c.submit(dask_sim, key=job_id, **inputs)
+        fut = c.submit(dask_sim, **inputs)
         fire_and_forget(fut)
-        return {"job_id": fut.key, "qlength": 1}
+        return {"job_id": job_id, "qlength": 1}
 
 
 def route_to_task(owner, app_name, endpoint, action):

--- a/distributed/cs-dask-sim/cs_dask_sim.py
+++ b/distributed/cs-dask-sim/cs_dask_sim.py
@@ -78,6 +78,11 @@ def dask_sim(meta_param_dict, adjustment, job_id, comp_url, comp_api_token, time
     callback for pushing the results back to the webapp. The callback is
     necessary becuase it will be called no matter what kinds of exceptions
     are thrown in this function.
+
+    This wrapper function is called with fire_and_forget. Since dask
+    "forgets" about this function but keeps track of the run_model task,
+    we give the run_model task the job_id. This makes it possible for the
+    webapp to query the job status.
     """
     start_time = time.time()
     partialled_cb = partial(
@@ -89,7 +94,7 @@ def dask_sim(meta_param_dict, adjustment, job_id, comp_url, comp_api_token, time
     )
     with worker_client() as c:
         print("c", c)
-        fut = c.submit(functions.run_model, meta_param_dict, adjustment)
+        fut = c.submit(functions.run_model, meta_param_dict, adjustment, key=job_id)
         fut.add_done_callback(partialled_cb)
         try:
             print("waiting on future", fut)


### PR DESCRIPTION
This PR assigns the simulation's ID to the `run_model` task instead of the wrapper task `cs_dask_sim.dask_sim`. If I understand correctly, dask "forgets" the wrapper task because it is started with [`fire_and_forget`](https://distributed.dask.org/en/latest/api.html#distributed.fire_and_forget). However, dask does keep track of the `run_model` task because its result is waited on like normal via `future.result()`.