### PR TITLE
Compute cluster updates/fixes

### DIFF
--- a/distributed/cs_cluster.py
+++ b/distributed/cs_cluster.py
@@ -230,6 +230,15 @@ class Cluster:
         app_deployment["spec"]["replicas"] = app.get("replicas", 1)
         app_deployment["spec"]["selector"]["matchLabels"]["app"] = name
         app_deployment["spec"]["template"]["metadata"]["labels"]["app"] = name
+        if "affinity" in app:
+            affinity_exp = {"key": "model", "operator": "In", "values": [app["affinity"]["model"]]}
+            app_deployment["spec"]["template"]["spec"]["affinity"] = {
+                "nodeAffinity": {
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                        "nodeSelectorTerms": [{"matchExpressions": [affinity_exp]}]
+                    }
+                }
+            }
 
         container_config = app_deployment["spec"]["template"]["spec"]["containers"][0]
 

--- a/distributed/dockerfiles/Dockerfile.tasks
+++ b/distributed/dockerfiles/Dockerfile.tasks
@@ -2,8 +2,9 @@ ARG TAG
 FROM celerybase
 
 # install packages here
-# install packages necessary for celery,
+# install packages necessary for celery and dask.
 RUN pip install -r requirements.txt
+RUN conda install -c conda-forge lz4
 
 ARG TITLE
 ARG OWNER


### PR DESCRIPTION
- Set affinity for dask workers. In PR #229, I tried to use size-based affinity to schedule pods on appropriate nodes. It seems like there are still a lot of unused resources. In this PR and follow up PRs for the celery workers, I'm going to try setting a model-based affinity. This means models like OG-USA and Tax-Brain that are particularly resource intensive will have each have a one-node cluster that they will use and the other models and services will run on the smaller nodes.

- Install lz4 for all workers. This guarantees that dask workers will have the same compression library as the scheduler which is installed from the official [dask/daskdev](https://hub.docker.com/u/daskdev/#!) docker image.