### PR TITLE
[WIP] Home page/navigation improvements

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -53,14 +53,22 @@
       <div class="collapse navbar-collapse" id="navbarTogglerDemo02">
         <ul class="navbar-nav mr-auto mt-2 mt-lg-0 mobile-mb-3">
           <li class="nav-item dropdown">
-            <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown"
-              aria-haspopup="true" aria-expanded="false">
-              Models
+            <a class="nav-link" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true"
+              aria-expanded="false">
+              <i class="fas fa-plus"></i>
             </a>
             <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+              {% if recent_project_list %}
+              <h6 class="dropdown-header">Recents</h6>
+              {% for owner, project, url in recent_project_list %}
+              <a class="dropdown-item" href="{{url}}new/">{{owner}}/{{project}}</a>
+              {% endfor %}
+              <div class="dropdown-divider"></div>
+              <h6 class="dropdown-header">Suggested</h6>
+              {% endif %}
               <!-- Add new projects to the dropdown menu here! -->
               {% for owner, project, url in project_list %}
-              <a class="dropdown-item" href="{{url}}">{{owner}}/{{project}}</a>
+              <a class="dropdown-item" href="{{url}}new/">{{owner}}/{{project}}</a>
               {% endfor %}
             </div>
           </li>

--- a/webapp/apps/comp/models.py
+++ b/webapp/apps/comp/models.py
@@ -382,7 +382,7 @@ class Simulation(models.Model):
         return self.project.run_cost(self.run_time, adjust=True)
 
     def __str__(self):
-        return f"{self.project}#{self.model_pk} by {self.owner.user}"
+        return f"{str(self.project)}#{self.model_pk} by {self.owner.user}"
 
     def parent_sims(self, user=None):
         """

--- a/webapp/apps/pages/context_processors.py
+++ b/webapp/apps/pages/context_processors.py
@@ -1,7 +1,9 @@
+from django.db.models import Max
+
 from webapp.apps.users.models import Project
 
 
-def project_list(request):
+def project_list(request, limit_recent=2):
     projects = Project.objects.filter(listed=True).order_by(
         "owner__user__username", "title"
     )
@@ -10,4 +12,18 @@ def project_list(request):
         project_list.append(
             (project.owner.user.username, project.title, project.app_url)
         )
-    return {"project_list": project_list}
+
+    recent_project_list = []
+    # if request.user.is_authenticated and getattr(request.user, "profile", False):
+    #     recent_sims_by_project = (
+    #         request
+    #         .user.profile.sims.annotate(recent_creation_date=Max("creation_date")).first(creation_date="recent_creation_date").order_by("-creation_date")
+    #     )
+
+    #     for sim in recent_sims_by_project[:limit_recent]:
+    #         project = sim.project
+    #         recent_project_list.append(
+    #             (project.owner.user.username, project.title, project.app_url)
+    #         )
+
+    return {"project_list": project_list, "recent_project_list": recent_project_list}

--- a/webapp/apps/pages/tests/test_context_processors.py
+++ b/webapp/apps/pages/tests/test_context_processors.py
@@ -1,12 +1,17 @@
 import pytest
+from django.test import RequestFactory
 
 from webapp.apps.users.models import Project
 from webapp.apps.pages.context_processors import project_list
 
 
 @pytest.mark.django_db
-def test_project_list():
-    projs = project_list(None)
+def test_project_list(profile):
+    factory = RequestFactory()
+    mockrequest = factory.get("/")
+    mockrequest.user = profile.user
+
+    projs = project_list(mockrequest)
     assert projs
     assert len(projs["project_list"]) == Project.objects.filter(listed=True).count()
     assert isinstance(projs, dict)

--- a/webapp/apps/pages/views.py
+++ b/webapp/apps/pages/views.py
@@ -12,12 +12,18 @@ class HomeView(View):
     def get(self, request, *args, **kwargs):
         if request.user.is_authenticated:
             profile = request.user.profile
+            if request.GET.get("all") == "true":
+                limit = None
+            else:
+                limit = 50
             return render(
                 request,
                 self.profile_template,
                 context={
                     "username": request.user.username,
-                    "runs": profile.sims_breakdown(self.projects, public_only=False),
+                    "runs": profile.sims_breakdown(
+                        self.projects, public_only=False, limit=limit
+                    ),
                     "show_readme": False,
                     "projects": self.projects.filter(owner=profile),
                 },
@@ -32,12 +38,19 @@ class ProfileView(View):
     def get(self, request, *args, **kwargs):
         username = kwargs["username"]
         profile = get_object_or_404(Profile, user__username__iexact=username)
+        if request.GET.get("all") == "true":
+            limit = None
+        else:
+            limit = 50
+
         return render(
             request,
             self.profile_template,
             context={
                 "username": request.user.username,
-                "runs": profile.sims_breakdown(self.projects, public_only=True),
+                "runs": profile.sims_breakdown(
+                    self.projects, public_only=True, limit=limit
+                ),
                 "show_readme": False,
                 "projects": self.projects.filter(owner=profile, listed=True),
             },


### PR DESCRIPTION
This PR aims to make a few small improvements to the home page:
- Dropdown points directly to the `[owner]/[title]/new/` page. This makes it easier to get to a new simulation page no matter where you are on the site.
  - @MattHJensen perhaps, we should include easier access to the model README on the simulation page with this?

- Add a recent section to the dropdowns

- A cosmetic change from "Models V" to just a plus sign.

- [Maybe] Adds a limit to the default number of simulations shown per project on the home page. Once you've run a few hundred simulations, the home page takes quite a bit to load and render all of the simulations. The assumption for this change is that most people typically only need to refer to their most recent 50 or so simulations.
  - There would be a big button that takes you to `https://compute.studio/?all=true` that lists all of the simulations.
  - It may be better to hold off on this until we re-design the home page.


TODO:

- [ ] Fix most recent used project query.
- [ ] Test limit on number of simulations shown per model on home and profile page.
- [ ] Green plus button

![Screenshot from 2020-01-23 14-59-09](https://user-images.githubusercontent.com/9206065/73019348-6cccdf80-3df1-11ea-86c1-908dc11e62c5.png)
