### PR TITLE
Fix: Readme should copy over from the parent simulation

### DIFF
--- a/webapp/apps/comp/asyncsubmit.py
+++ b/webapp/apps/comp/asyncsubmit.py
@@ -93,6 +93,7 @@ class SubmitInputs:
         if not self.sim.parent_sim and parent_sim:
             self.sim.parent_sim = parent_sim
             self.sim.title = parent_sim.title
+            self.sim.readme = parent_sim.readme
             if notify_on_completion is not None:
                 self.sim.notify_on_completion = notify_on_completion
             self.sim.save()

--- a/webapp/apps/comp/tests/test_asyncsubmit.py
+++ b/webapp/apps/comp/tests/test_asyncsubmit.py
@@ -46,6 +46,7 @@ def test_parents_submit(db, get_inputs, meta_param_dict, profile):
     submit_inputs0, submit_sim0 = _submit_sim(inputs)
     _ = submit_sim0.submit()
     submit_sim0.sim.title = "hello world"
+    submit_sim0.sim.readme = [{"text": "readme"}]
     submit_sim0.sim.save()
 
     assert submit_inputs0.inputs.parent_sim == None
@@ -65,6 +66,7 @@ def test_parents_submit(db, get_inputs, meta_param_dict, profile):
     assert submit_inputs1.inputs.parent_sim == submit_sim0.sim
     assert submit_sim1.sim.parent_sim == submit_sim0.sim
     assert submit_sim1.sim.title == "hello world"
+    assert submit_sim1.sim.readme == [{"text": "readme"}]
 
 
 @pytest.mark.parametrize("notify_on_completion", [True, False])


### PR DESCRIPTION
Prior to this PR, only the title copied over from a parent simulation. This PR copies the readme over, too.
