### PR TITLE
Configuration updates and Job cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ secret.yaml
 *outputs-processor-deployment.yaml
 
 *google-creds.json
+*cs-config.yaml

--- a/workers/cs-config.yaml
+++ b/workers/cs-config.yaml
@@ -1,4 +1,0 @@
-CS_URL: null
-CS_API_TOKEN: null
-PROJECT: null
-TAG: null

--- a/workers/cs_workers/cli.py
+++ b/workers/cs_workers/cli.py
@@ -15,14 +15,16 @@ import cs_workers.models.executors.api_task
 
 
 TAG = os.environ.get("TAG", "")
-PROJECT = os.environ.get("PROJECT", "cs-workers-dev")
+PROJECT = os.environ.get("PROJECT")
 CS_URL = os.environ.get("CS_URL", None)
+BUCKET = os.environ.get("BUCKET")
 
 defaults = dict(
     TAG=datetime.datetime.now().strftime("%Y-%m-%d"),
-    PROJECT="cs-workers-dev",
+    PROJECT=None,
     CS_URL=None,
     CS_API_TOKEN=None,
+    BUCKET=None,
 )
 
 
@@ -36,7 +38,7 @@ def load_env():
     else:
         user_config = {}
 
-    for var in ["TAG", "PROJECT", "CS_URL", "CS_API_TOKEN"]:
+    for var in ["TAG", "PROJECT", "CS_URL", "CS_API_TOKEN", "BUCKET"]:
         if os.environ.get(var):
             config[var] = os.environ.get(var)
         elif user_config.get(var):
@@ -49,6 +51,7 @@ def cli():
     parser = argparse.ArgumentParser(description="C/S Workers CLI")
     parser.add_argument("--tag", required=False, default=config["TAG"])
     parser.add_argument("--project", required=False, default=config["PROJECT"])
+    parser.add_argument("--bucket", required=False, default=config["BUCKET"])
     parser.add_argument("--cs-url", required=False, default=config["CS_URL"])
     parser.add_argument(
         "--cs-api-token", required=False, default=config["CS_API_TOKEN"]

--- a/workers/cs_workers/models/clients/job.py
+++ b/workers/cs_workers/models/clients/job.py
@@ -144,7 +144,7 @@ class Job:
         self.rclient.set(job_id, json.dumps(job_kwargs))
 
     def create(self):
-        return self.api_client.create_namespaced_job(body=self.job, namespace="prod")
+        return self.api_client.create_namespaced_job(body=self.job, namespace="default")
 
     def delete(self):
         return self.api_client.delete_namespaced_job(

--- a/workers/cs_workers/models/clients/job.py
+++ b/workers/cs_workers/models/clients/job.py
@@ -61,6 +61,7 @@ class Job:
         ]
         for sec in [
             "CS_URL",
+            "BUCKET",
             "REDIS_HOST",
             "REDIS_PORT",
             "REDIS_EXECUTOR_PW",

--- a/workers/cs_workers/models/manage.py
+++ b/workers/cs_workers/models/manage.py
@@ -38,7 +38,7 @@ class Manager:
         tag,
         models=None,
         base_branch="origin/master",
-        cs_url=os.environ.get("CS_URL"),
+        cs_url=None,
         cs_api_token=None,
         kubernetes_target=None,
         use_kind=False,
@@ -248,7 +248,7 @@ class Manager:
             secret_config["stringData"][name] = value
 
         if not secret_config["stringData"]:
-            return
+            secret_config["stringData"] = dict()
 
         if self.kubernetes_target == "-":
             sys.stdout.write(yaml.dump(secret_config))

--- a/workers/cs_workers/models/secrets.py
+++ b/workers/cs_workers/models/secrets.py
@@ -5,8 +5,6 @@ import os
 from cs_workers.utils import clean
 from cs_workers import secrets
 
-PROJECT = os.environ.get("PROJECT", "cs-workers-dev")
-
 
 class ModelSecrets(secrets.Secrets):
     def __init__(self, owner=None, title=None, name=None, project=None):

--- a/workers/cs_workers/services/manage.py
+++ b/workers/cs_workers/services/manage.py
@@ -72,6 +72,7 @@ class Manager:
         self,
         tag,
         project,
+        bucket=None,
         kubernetes_target="kubernetes/",
         use_kind=False,
         cs_url=None,
@@ -79,6 +80,7 @@ class Manager:
     ):
         self.tag = tag
         self.project = project
+        self.bucket = bucket
         self.use_kind = use_kind
         self.cs_url = cs_url
         self._cs_api_token = cs_api_token
@@ -220,9 +222,15 @@ class Manager:
         self.write_config("redis-master-Deployment.yaml", deployment)
 
     def write_secret(self):
+        assert self.bucket
+        assert self.cs_url
+        assert self.cs_api_token
+        assert self.project
         secrets = copy.deepcopy(self.secret_template)
         secrets["stringData"]["CS_URL"] = self.cs_url
         secrets["stringData"]["CS_API_TOKEN"] = self.cs_api_token
+        secrets["stringData"]["BUCKET"] = self.bucket
+        secrets["stringData"]["PROJECT"] = self.project
         redis_secrets = self.redis_secrets()
         for name, sec in redis_secrets.items():
             if sec is not None:
@@ -281,6 +289,7 @@ def manager_from_args(args: argparse.Namespace):
     return Manager(
         tag=args.tag,
         project=args.project,
+        bucket=args.bucket,
         kubernetes_target=getattr(args, "out", None),
         use_kind=getattr(args, "use_kind", None),
         cs_url=getattr(args, "cs_url", None),

--- a/workers/cs_workers/services/manage.py
+++ b/workers/cs_workers/services/manage.py
@@ -165,6 +165,8 @@ class Manager:
             "scheduler-RBAC.yaml",
             "outputs-processor-Service.yaml",
             "redis-master-Service.yaml",
+            "job-cleanup-Deployment.yaml",
+            "job-cleanup-RBAC.yaml",
         ]
         for filename in config_filenames:
             with open(self.templates_dir / "services" / f"{filename}", "r") as f:

--- a/workers/cs_workers/services/outputs_processor.py
+++ b/workers/cs_workers/services/outputs_processor.py
@@ -12,6 +12,7 @@ import cs_storage
 
 CS_URL = os.environ.get("CS_URL")
 CS_API_TOKEN = os.environ.get("CS_API_TOKEN")
+BUCKET = os.environ.get("BUCKET")
 
 
 async def write(task_id, outputs):
@@ -54,6 +55,7 @@ class Push(tornado.web.RequestHandler):
 
 
 def get_app():
+    assert CS_URL and CS_API_TOKEN and BUCKET
     return tornado.web.Application(
         [(r"/write/", Write), (r"/push/", Push)], debug=True, autoreload=True
     )

--- a/workers/cs_workers/services/scheduler.py
+++ b/workers/cs_workers/services/scheduler.py
@@ -15,7 +15,7 @@ from cs_workers.config import ModelConfig
 
 
 CS_URL = os.environ.get("CS_URL")
-
+PROJECT = os.environ.get("PROJECT")
 
 redis_conn = dict(
     username="scheduler",
@@ -73,7 +73,7 @@ class Scheduler(tornado.web.RequestHandler):
         elif task_name == "sim":
             tag = payload["tag"]
             client = job.Job(
-                "cs-workers-dev",
+                PROJECT,
                 owner,
                 title,
                 tag=tag,
@@ -104,8 +104,9 @@ class SyncProjects(tornado.web.RequestHandler):
 
 
 def get_app():
+    assert PROJECT and CS_URL
     rclient = redis.Redis(**redis_conn)
-    config = ModelConfig("cs-workers-dev", cs_url=CS_URL, rclient=rclient)
+    config = ModelConfig(PROJECT, cs_url=CS_URL, rclient=rclient)
     config.set_projects()
     return tornado.web.Application(
         [

--- a/workers/cs_workers/templates/secret.template.yaml
+++ b/workers/cs_workers/templates/secret.template.yaml
@@ -4,9 +4,8 @@ metadata:
   name: worker-secret
 type: Opaque
 stringData:
-  # CS_URL: https://dev.compute.studio
-  CS_URL: http://hdoupe.ngrok.io
-  BUCKET: cs-outputs-dev
+  CS_URL: ""
+  BUCKET: ""
   OUTPUTS_VERSION: "v1"
   REDIS_HOST: redis-master
   REDIS_DB: ""

--- a/workers/cs_workers/templates/services/job-cleanup-Deployment.yaml
+++ b/workers/cs_workers/templates/services/job-cleanup-Deployment.yaml
@@ -1,0 +1,17 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: job-cleanup
+spec:
+  schedule: "*/30 * * * *"
+  successfulJobsHistoryLimit: 0
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: job-cleanup
+          containers:
+            - name: kubectl-container
+              image: bitnami/kubectl:latest
+              command: ["sh", "-c", "kubectl delete jobs --field-selector status.successful=1"]
+          restartPolicy: Never

--- a/workers/cs_workers/templates/services/job-cleanup-RBAC.yaml
+++ b/workers/cs_workers/templates/services/job-cleanup-RBAC.yaml
@@ -1,28 +1,28 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: scheduler
+  name: job-cleanup
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: job-admin
+  name: job-remove
   namespace: default
 rules:
   - apiGroups: ["batch", "extensions"]
     resources: ["jobs"]
-    verbs: ["get", "list", "watch", "create", "update", "delete"]
+    verbs: ["get", "list", "watch", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: job-admin
+  name: job-remove
   namespace: default
 subjects:
   - kind: ServiceAccount
-    name: scheduler
+    name: job-cleanup
     namespace: default
 roleRef:
   kind: Role
-  name: job-admin
+  name: job-remove
   apiGroup: rbac.authorization.k8s.io

--- a/workers/cs_workers/templates/services/outputs-processor-Deployment.template.yaml
+++ b/workers/cs_workers/templates/services/outputs-processor-Deployment.template.yaml
@@ -18,11 +18,6 @@ spec:
           ports:
             - containerPort: 8888
           env:
-            - name: PROJECT
-              valueFrom:
-                secretKeyRef:
-                  name: worker-secret
-                  key: PROJECT
             - name: BUCKET
               valueFrom:
                 secretKeyRef:

--- a/workers/cs_workers/templates/services/outputs-processor-Deployment.template.yaml
+++ b/workers/cs_workers/templates/services/outputs-processor-Deployment.template.yaml
@@ -18,6 +18,11 @@ spec:
           ports:
             - containerPort: 8888
           env:
+            - name: PROJECT
+              valueFrom:
+                secretKeyRef:
+                  name: worker-secret
+                  key: PROJECT
             - name: BUCKET
               valueFrom:
                 secretKeyRef:

--- a/workers/cs_workers/templates/services/scheduler-Deployment.template.yaml
+++ b/workers/cs_workers/templates/services/scheduler-Deployment.template.yaml
@@ -24,6 +24,11 @@ spec:
                 secretKeyRef:
                   name: worker-secret
                   key: CS_URL
+            - name: PROJECT
+              valueFrom:
+                secretKeyRef:
+                  name: worker-secret
+                  key: PROJECT
             - name: REDIS_HOST
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
- Adds missing configuration variables `BUCKET` and `PROJECT` that were hard-coded.
  - Adds checks for these variables when they are required and removes reliance on default, hard-coded values.
- Adds `cs-config.yaml` to `.gitignore`. Non-secret deployment configuration variables will be set in this file instead of as environment variables.
- Adds a [CronJob](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/) to clean up Jobs that have finished successfully. The Job docs reference an alpha level feature [`ttlSecondsAfterFinished`](https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/#ttl-mechanism-for-finished-jobs) that lets you set a window after which successful jobs are cleaned up. Unfortunately, most managed kubernetes services do not let you opt into alpha level features. However, a CronJob accomplishes the same goal. In the future, we may want to move job status tracking and clean up into the Scheduler.

- Moves resources back into default namespace now that the deployment has been completed successfully.