### PR TITLE
Update subscription logic

### DIFF
--- a/webapp/apps/billing/tests/test_models.py
+++ b/webapp/apps/billing/tests/test_models.py
@@ -133,7 +133,7 @@ class TestStripeModels:
         for sub in customer.subscriptions.all():
             assert sub.cancel_at_period_end
 
-    def test_customer_sync_subscriptions(self, db, client):
+    def test_customer_sync_subscriptions(self, db, client, mock_sync_projects):
         u = User.objects.create_user(
             username="synctest", email="synctest@email.com", password="syncer2222"
         )

--- a/webapp/apps/billing/tests/test_utils.py
+++ b/webapp/apps/billing/tests/test_utils.py
@@ -3,9 +3,11 @@ import pytest
 from django.contrib.auth import get_user_model
 
 from webapp.apps.billing.utils import has_payment_method, ChargeRunMixin
-from webapp.apps.billing.models import UsageRecord
+from webapp.apps.billing.models import UsageRecord, SubscriptionItem
 from webapp.apps.comp.models import Inputs, Simulation
 from webapp.apps.users.models import Profile, Project
+
+from .utils import gen_blank_customer
 
 User = get_user_model()
 
@@ -44,3 +46,82 @@ def test_pay_per_sim(db, customer, pay_per_sim):
         assert ur_count + 1 == UsageRecord.objects.count()
     else:
         assert ur_count == UsageRecord.objects.count()
+
+
+@pytest.mark.requires_stripe
+def test_charge_run_adds_plans(db):
+    """
+    Create new user and make sure that the model's plan is added with ChargeRun.
+    """
+
+    # setup
+    project = Project.objects.get(title="Used-for-testing")
+    profile = gen_blank_customer(
+        username="no_plans", email="tester@email.com", password="heyhey2222"
+    )
+    inputs = Inputs.objects.create(inputs_style="paramtools", project=project)
+    sim = Simulation.objects.create(
+        inputs=inputs,
+        project=project,
+        model_pk=Simulation.objects.next_model_pk(project),
+        owner=profile,
+    )
+
+    # No plans set for model right now.
+    plan = project.product.plans.get(usage_type="metered")
+    assert (
+        SubscriptionItem.objects.filter(
+            subscription__customer=profile.user.customer, plan=plan
+        ).count()
+        == 0
+    )
+
+    cr = ChargeRunMixin()
+    cr.charge_run(sim, {"task_times": [100]})
+
+    # model's plan has been added.
+    assert (
+        SubscriptionItem.objects.filter(
+            subscription__customer=profile.user.customer, plan=plan
+        ).count()
+        == 1
+    )
+
+
+@pytest.mark.requires_stripe
+def test_charge_run_with_sponsored_model(db):
+    """
+    Create new user and make sure no plans are added after running sponsored model.
+    """
+    # setup
+    project = Project.objects.get(title="Used-for-testing-sponsored-apps")
+    profile = gen_blank_customer(
+        username="no_plans_sponsored", email="tester@email.com", password="heyhey2222"
+    )
+    inputs = Inputs.objects.create(inputs_style="paramtools", project=project)
+    sim = Simulation.objects.create(
+        inputs=inputs,
+        project=project,
+        model_pk=Simulation.objects.next_model_pk(project),
+        owner=profile,
+    )
+
+    # No plans set for model.
+    plan = project.product.plans.get(usage_type="metered")
+    assert (
+        SubscriptionItem.objects.filter(
+            subscription__customer=profile.user.customer, plan=plan
+        ).count()
+        == 0
+    )
+
+    cr = ChargeRunMixin()
+    cr.charge_run(sim, {"task_times": [100]})
+
+    # Still no plans.
+    assert (
+        SubscriptionItem.objects.filter(
+            subscription__customer=profile.user.customer, plan=plan
+        ).count()
+        == 0
+    )

--- a/webapp/apps/billing/views.py
+++ b/webapp/apps/billing/views.py
@@ -44,11 +44,7 @@ def update_payment(user, stripe_token):
         user.customer.update_source(stripe_token)
     else:  # create customer.
         stripe_customer = stripe.Customer.create(email=user.email, source=stripe_token)
-        customer = Customer.construct(stripe_customer, user=user)
-        if Project.objects.count() > 0:
-            customer.sync_subscriptions()
-        else:
-            print("No projects yet.")
+        Customer.construct(stripe_customer, user=user)
 
 
 class Webhook(View):

--- a/webapp/apps/comp/compute.py
+++ b/webapp/apps/comp/compute.py
@@ -89,7 +89,7 @@ class SyncCompute(Compute):
                         return
                     data = response.json()
                 else:
-                    print("FAILED: ", WORKER_HN)
+                    print("FAILED: ", WORKER_HN, response.status_code)
                     attempts += 1
             except Timeout:
                 print("Couldn't submit to: ", WORKER_HN)

--- a/webapp/apps/conftest.py
+++ b/webapp/apps/conftest.py
@@ -4,6 +4,7 @@ import datetime
 import functools
 
 import requests
+import requests_mock
 import pytest
 import stripe
 import paramtools as pt
@@ -390,3 +391,12 @@ def worker_url():
 @pytest.fixture
 def comp_api_user(db):
     return Profile.objects.get(user__username="comp-api-user")
+
+
+@pytest.fixture
+def mock_sync_projects(db, worker_url):
+    with requests_mock.Mocker(real_http=True) as mock:
+        mock.register_uri(
+            "POST", f"{worker_url}sync/",
+        )
+        yield

--- a/webapp/apps/conftest.py
+++ b/webapp/apps/conftest.py
@@ -92,8 +92,7 @@ def django_db_setup(django_db_setup, django_db_blocker):
                 stripe_customer = stripe.Customer.create(
                     email=u.email, source="tok_bypassPending"
                 )
-                customer, _ = Customer.get_or_construct(stripe_customer.id, u)
-            Customer.objects.sync_subscriptions()
+                Customer.get_or_construct(stripe_customer.id, u)
 
 
 @pytest.fixture

--- a/webapp/apps/publish/tests/test_views.py
+++ b/webapp/apps/publish/tests/test_views.py
@@ -2,7 +2,6 @@ import json
 from decimal import Decimal
 
 import pytest
-import requests_mock
 
 from django.contrib.auth import get_user_model, get_user
 from guardian.shortcuts import assign_perm, remove_perm
@@ -11,15 +10,6 @@ from webapp.apps.comp.models import Simulation
 from webapp.apps.users.models import Project, Profile
 
 from webapp.apps.users.serializers import ProjectSerializer
-
-
-@pytest.fixture
-def mock_sync_projects(db, worker_url):
-    with requests_mock.Mocker(real_http=True) as mock:
-        mock.register_uri(
-            "POST", f"{worker_url}sync/",
-        )
-        yield
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
When users sign up on C/S, they do not have any Stripe data associated with them. When they add their credit card, a Stripe `Customer` object is set up for them. This `Customer` object is in the C/S database and on Stripe.com. Prior to this PR, the user was also signed up to a metered (i.e. pay per usage) subscription to all models on C/S. This PR updates this flow so that a model's plan is added to a user's stripe usage subscription only when that user uses the model and it is paid.

Having a usage plan for each model is helpful for seeing a breakdown on model usage and costs directly in the invoice, but it may make sense one day to have a generic C/S compute usage plan and to provide the cost breakdowns in the C/S GUI.