### PR TITLE
Use context manager to close Dask Client

### DIFF
--- a/workers/cs_workers/services/outputs_processor.py
+++ b/workers/cs_workers/services/outputs_processor.py
@@ -16,9 +16,9 @@ BUCKET = os.environ.get("BUCKET")
 
 
 async def write(task_id, outputs):
-    client = await Client(asynchronous=True, processes=False)
-    outputs = cs_storage.deserialize_from_json(outputs)
-    res = await client.submit(cs_storage.write, task_id, outputs)
+    async with await Client(asynchronous=True, processes=False) as client:
+        outputs = cs_storage.deserialize_from_json(outputs)
+        res = await client.submit(cs_storage.write, task_id, outputs)
     return res
 
 


### PR DESCRIPTION
- Fixes memory leak caused by not closing the dask client.