### PR TITLE
Run model tests with secrets

### DIFF
--- a/workers/setup.py
+++ b/workers/setup.py
@@ -29,6 +29,7 @@ setuptools.setup(
         "distributed",
         "tornado",
         "cs-storage",
+        "docker",
     ],
     include_package_data=True,
     entry_points={


### PR DESCRIPTION
This PR makes model secrets available when running the CS tests, resolving https://github.com/compute-tooling/compute-studio-publish/pull/69#issuecomment-663124091. 

This swaps from the Docker CLI to the Docker [Python client](https://github.com/docker/docker-py). Since the Python client passes commands and their config options over a rest api, we can sidestep the problem of potentially exposing secrets by passing them through the command line.

This PR also fixes a potential security problem if the secret value is printed on accident through logging from the model, tracebacks from an error, or from the testing software (pytest). For example:

![Screenshot from 2020-07-24 07-01-24](https://user-images.githubusercontent.com/9206065/88384987-812b6e00-cd7b-11ea-9c82-fd9d1932472d.png)
