### PR TITLE
Update webapp for private storage bucket

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -23,3 +23,6 @@ ADD ./templates /code/templates/
 ADD ./manage.py /code/
 ADD ./static /code/static/
 RUN python manage.py collectstatic --noinput
+
+ADD ./google-creds.json /code/google-creds.json
+ENV GOOGLE_APPLICATION_CREDENTIALS=/code/google-creds.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - DEBUG=True
       - WORKERS=${WORKERS}
       - LOCAL=True
-      - BUCKET=cs-outputs-dev
+      - BUCKET=cs-outputs-dev-private
       - MAILGUN_API_KEY=${MAILGUN_API_KEY}
       - USE_STRIPE=${USE_STRIPE}
       - STRIPE_SECRET=${STRIPE_SECRET}

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,4 +21,4 @@ newrelic
 hashids
 django-rest-auth
 django-allauth
-cs-storage>=1.8.1
+cs-storage>=1.11.0

--- a/webapp/apps/comp/tests/test_asyncviews.py
+++ b/webapp/apps/comp/tests/test_asyncviews.py
@@ -315,6 +315,7 @@ class RunMockModel(CoreTestMixin):
 
     def get_paths(self, model_pk: int):
         def fetch_sims(exp_resp: int):
+            output_id = self.sim.outputs["outputs"]["renderable"]["outputs"][0]["id"]
             api_paths = [
                 f"/{self.owner}/{self.title}/api/v1/{model_pk}/remote/",
                 f"/{self.owner}/{self.title}/api/v1/{model_pk}/",
@@ -323,6 +324,7 @@ class RunMockModel(CoreTestMixin):
             paths = [
                 f"/{self.owner}/{self.title}/{model_pk}/",
                 f"/{self.owner}/{self.title}/{model_pk}/edit/",
+                f"/storage/screenshots/{output_id}.png",
             ]
             for path in api_paths:
                 resp = self.api_client.get(path)

--- a/webapp/apps/comp/views/__init__.py
+++ b/webapp/apps/comp/views/__init__.py
@@ -6,6 +6,7 @@ from .views import (
     OutputsView,
     PermissionPendingView,
     PermissionGrantedView,
+    DataView,
 )
 
 from .api import (

--- a/webapp/apps/comp/views/api.py
+++ b/webapp/apps/comp/views/api.py
@@ -242,9 +242,15 @@ class BaseDetailAPIView(GetOutputsObjectMixin, APIView):
             if not as_remote:
                 data["outputs"] = cs_storage.read(outputs)
             else:
-                data["outputs"]["outputs"] = cs_storage.add_screenshot_links(
-                    data["outputs"]["outputs"]
-                )
+                if self.request.is_secure():
+                    protocol = "https"
+                else:
+                    protocol = "http"  # local dev.
+                base_url = f"{protocol}://{self.request.get_host()}"
+                for rem_output in data["outputs"]["outputs"]["renderable"]["outputs"]:
+                    rem_output[
+                        "screenshot"
+                    ] = f"{base_url}/storage/screenshots/{rem_output['id']}.png"
             return Response(data, status=status.HTTP_200_OK)
         elif self.object.traceback is not None:
             return Response(data, status=status.HTTP_200_OK)

--- a/webapp/apps/comp/views/views.py
+++ b/webapp/apps/comp/views/views.py
@@ -289,3 +289,22 @@ class OutputsDownloadView(GetOutputsObjectMixin, View):
             "Content-Disposition"
         ] = f"attachment; filename={self.object.json_filename()}"
         return resp
+
+
+class DataView(View):
+    def get(self, request, *args, **kwargs):
+        data_id = kwargs["data_id"]
+
+        if data_id.endswith(".png"):
+            data_id = data_id[:-4]
+
+        self.object = Simulation.objects.get_object_from_screenshot(
+            data_id, http_404_on_fail=True
+        )
+
+        if not self.object.has_read_access(request.user):
+            raise PermissionDenied()
+
+        pic = cs_storage.read_screenshot(kwargs["data_id"])
+
+        return HttpResponse(pic, content_type="image/png")

--- a/webapp/urls.py
+++ b/webapp/urls.py
@@ -32,6 +32,11 @@ urlpatterns = [
     path("users/", include("webapp.apps.users.urls")),
     path("users/", include("django.contrib.auth.urls")),
     path("billing/", include("webapp.apps.billing.urls")),
+    path(
+        "storage/screenshots/<str:data_id>",
+        compviews.DataView.as_view(),
+        name="data__view",
+    ),
     path("outputs/api/", compviews.OutputsAPIView.as_view(), name="outputs_api"),
     path("inputs/api/", compviews.MyInputsAPIView.as_view(), name="myinputs_api"),
     url(r"^rest-auth/", include("rest_auth.urls")),

--- a/workers/requirements.txt
+++ b/workers/requirements.txt
@@ -4,5 +4,5 @@ pytest
 toolz
 boto3
 kubernetes
-cs-storage>=1.10.1
+cs-storage>=1.11.0
 pyyaml

--- a/workers/setup.py
+++ b/workers/setup.py
@@ -28,7 +28,7 @@ setuptools.setup(
         "dask",
         "distributed",
         "tornado",
-        "cs-storage",
+        "cs-storage>=1.11.0",
     ],
     include_package_data=True,
     entry_points={


### PR DESCRIPTION
This PR updates the webapp to work with a private storage bucket. Prior to this PR, the storage bucket was public and anyone could read files directly from it. Granted, the name of each zip file and picture were UUID's and thus, semi-private. However, this makes all files completely private, and access to them is controlled through the C/S authentication system.

The only substantial change required to make this happen was to route the screenshots through a new url `/storage/screenshots/[data_id].png`. Thanks to the Postgresql JSON field, this was easy to do. It turns out that you can query deeply nested JSON fields such as the "id" field in this data:

```json
{
    "outputs": {
        "renderable": {
            "outputs": [
                {
                    "id": "3da9cbab-e634-4381-b2a2-0fd8df28c414",
                    "title": "Max Scherzer v. All batters",
                    "filename": "Max Scherzer v. All batters.json",
                    "media_type": "bokeh"
                },
                {
                    "id": "1dd082e9-bc92-43c6-ac55-62dadebefe76",
                    "title": "Max Scherzer v. Brian McCann",
                    "filename": "Max Scherzer v. Brian McCann.json",
                    "media_type": "bokeh"
                }
            ]
        }
    }
}
```

This query will then find a `Simulation` object with an output that has the queried ID.
```python
Simulation.objects.get(
    outputs__outputs__renderable__outputs__contains=[{"id": "1dd082e9-bc92-43c6-ac55-62dadebefe76"}],
)
```

Not going directly through to the Google Storage link for loading the screenshots seems to have a minor performance impact (100-200ms per screenshot load), but the privacy trade-off makes this tolerable.
