### PR TITLE
Deployment fixes

### DIFF
--- a/workers/cs_workers/dockerfiles/Dockerfile.scheduler
+++ b/workers/cs_workers/dockerfiles/Dockerfile.scheduler
@@ -22,4 +22,6 @@ RUN cd /home/ && pip install -e .
 
 WORKDIR /home
 
+ENV PYTHONUNBUFFERED 1
+
 CMD ["csw", "scheduler", "--start"]

--- a/workers/cs_workers/models/manage.py
+++ b/workers/cs_workers/models/manage.py
@@ -302,6 +302,8 @@ class Manager(BaseManager):
         return secret_config
 
     def _write_api_task(self, app):
+        if app["tech"] != "python-paramtools":
+            return
         deployment = copy.deepcopy(self.api_task_template)
         safeowner = clean(app["owner"])
         safetitle = clean(app["title"])

--- a/workers/cs_workers/services/manage.py
+++ b/workers/cs_workers/services/manage.py
@@ -396,7 +396,7 @@ def cli(subparsers: argparse._SubParsersAction, config=None, **kwargs):
     config_parser.add_argument("--out", "-o")
     config_parser.add_argument("--update-redis", action="store_true")
     config_parser.add_argument(
-        "--cluster-host", required=False, default=config["CLUSTER_HOST"]
+        "--cluster-host", required=False, default=config.get("CLUSTER_HOST")
     )
     config_parser.add_argument("--update-dns", action="store_true")
     config_parser.set_defaults(func=config_)

--- a/workers/cs_workers/services/manage.py
+++ b/workers/cs_workers/services/manage.py
@@ -176,7 +176,7 @@ class Manager:
         run(f"{cmd_prefix} {self.cr}/{self.project}/outputs_processor:{self.tag}")
         run(f"{cmd_prefix} {self.cr}/{self.project}/scheduler:{self.tag}")
 
-    def config(self, update_redis=False):
+    def config(self, update_redis=False, update_dns=False):
         config_filenames = [
             "scheduler-Service.yaml",
             "scheduler-RBAC.yaml",
@@ -194,7 +194,8 @@ class Manager:
                 kind = config["kind"]
                 self.write_config(f"{name}-{kind}.yaml", config)
         self.write_scheduler_deployment()
-        self.write_scheduler_ingressroute()
+        if update_dns:
+            self.write_scheduler_ingressroute()
         self.write_outputs_processor_deployment()
         self.write_secret()
         if update_redis:
@@ -367,7 +368,7 @@ def push(args: argparse.Namespace):
 
 def config_(args: argparse.Namespace):
     cluster = manager_from_args(args)
-    cluster.config(update_redis=args.update_redis)
+    cluster.config(update_redis=args.update_redis, update_dns=args.update_dns)
 
 
 def port_forward(args: argparse.Namespace):
@@ -397,6 +398,7 @@ def cli(subparsers: argparse._SubParsersAction, config=None, **kwargs):
     config_parser.add_argument(
         "--cluster-host", required=False, default=config["CLUSTER_HOST"]
     )
+    config_parser.add_argument("--update-dns", action="store_true")
     config_parser.set_defaults(func=config_)
 
     pf_parser = svc_subparsers.add_parser("port-forward")


### PR DESCRIPTION
Fixes a few bugs that I encountered while deploying #308:
- Adds a flag to skip deploying viz apps since they are deployed on demand.
- Add a flag to skip updating dns configuration. This is helpful for setting the Cloudflare API token as a secret before creating the `IngressRoute` needed to update routing.
- Sets `PYTHONUNBUFFERED = 1` for the scheduler service for better access to logs printed to stdout.