### PR TITLE
Redirect viz links to new on python-paramtools projects

### DIFF
--- a/webapp/apps/comp/views/views.py
+++ b/webapp/apps/comp/views/views.py
@@ -161,6 +161,8 @@ class VizView(InputsMixin, View):
             owner__user__username__iexact=kwargs["username"],
             title__iexact=kwargs["title"],
         )
+        if project.tech == "python-paramtools":
+            return redirect(f"/{project.title}/{project.owner}/new/")
         context = self.project_context(request, project)
         if is_profile_active(request.user):
             owner = request.user.profile

--- a/webapp/apps/comp/views/views.py
+++ b/webapp/apps/comp/views/views.py
@@ -162,7 +162,7 @@ class VizView(InputsMixin, View):
             title__iexact=kwargs["title"],
         )
         if project.tech == "python-paramtools":
-            return redirect(f"/{project.title}/{project.owner}/new/")
+            return redirect(f"/{project.owner}/{project.title}/new/")
         context = self.project_context(request, project)
         if is_profile_active(request.user):
             owner = request.user.profile


### PR DESCRIPTION
A search engine bot picked up `https://compute.studio/PSLmodels/Tax-Brain/viz/` and keeps pinging it which is creating deployment objects in the database. This is then throwing off the deployment cleanup job.

Note: the `/viz/` link will be deprecated soon in favor of just linking to a model page, but not to worry, it will be done in a backwards compatible fashion to not break saved links.