### PR TITLE
Use git repo instead of local install for cs-workers

### DIFF
--- a/workers/cs_workers/dockerfiles/Dockerfile.model
+++ b/workers/cs_workers/dockerfiles/Dockerfile.model
@@ -30,10 +30,7 @@ RUN bash /home/install.sh
 RUN pip install "git+${REPO_URL}.git@${REPO_TAG}#egg=cs-config&subdirectory=cs-config"
 ADD ${RAW_REPO_URL}/${REPO_TAG}/cs-config/cs_config/tests/test_functions.py /home
 
-ADD ./setup.py .
-COPY ./cs_workers ./cs_workers
-RUN pip install -e . && pip install cs-kit pytest
-# RUN pip install "git+https://github.com/compute-tooling/compute-studio.git@master#egg=cs-workers&subdirectory=workers" cs-kit pytest
+RUN pip install "git+https://github.com/compute-tooling/compute-studio.git@master#egg=cs-workers&subdirectory=workers" cs-kit pytest
 ######################
 
 WORKDIR /home


### PR DESCRIPTION
This removes some changes I made for local development. I only just now noticed when doing an update in the compute-studio-publish repo.