### PR TITLE
Add a robots.txt file so crawlers don't trigger viz loads unncessarily

### DIFF
--- a/webapp/apps/pages/tests/test_views.py
+++ b/webapp/apps/pages/tests/test_views.py
@@ -39,3 +39,6 @@ class TestPageViews:
         resp = client.get("/about/")
         assert resp.status_code == 302, f"Expected 302, got {resp.status_code}"
         assert resp.url == ABOUT_URL
+
+    def test_get_robots(self, client):
+        assert client.get(f"/robots.txt").status_code == 200

--- a/webapp/apps/pages/urls.py
+++ b/webapp/apps/pages/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 
-from .views import HomeView, AboutView, PrivacyView, TermsView, DMCAView
+from .views import HomeView, AboutView, PrivacyView, TermsView, DMCAView, RobotsText
 
 
 urlpatterns = [
@@ -9,4 +9,5 @@ urlpatterns = [
     path("privacy/", PrivacyView.as_view(), name="privacy"),
     path("terms/", TermsView.as_view(), name="terms"),
     path("dmca/", DMCAView.as_view(), name="dmca"),
+    path("robots.txt", RobotsText.as_view(), name="robots"),
 ]

--- a/webapp/apps/pages/views.py
+++ b/webapp/apps/pages/views.py
@@ -1,7 +1,7 @@
-from django.shortcuts import render, get_object_or_404, redirect
+from django.shortcuts import render, get_object_or_404, redirect, HttpResponse
 from django.views import View
 
-from webapp.apps.users.models import Project, Profile
+from webapp.apps.users.models import Project, Profile, EmbedApproval
 
 ABOUT_URL = "https://about.compute.studio"
 
@@ -70,3 +70,24 @@ class DMCAView(View):
 
     def get(self, request, *args, **kwargs):
         return render(request, self.template)
+
+
+class RobotsText(View):
+    def get(self, request, *args, **kwargs):
+        lines = [
+            "User-Agent: *",
+        ]
+
+        viz_projects = Project.objects.exclude(
+            pk__in=Project.objects.filter(tech="python-paramtools")
+        )
+
+        for project in viz_projects:
+            lines.append(f"Disallow: /{project}/viz/")
+
+        eas = EmbedApproval.objects.all()
+
+        for ea in eas:
+            lines.append(f"Disallow: {ea.get_absolute_url()}")
+
+        return HttpResponse("\n".join(lines), content_type="text/plain")


### PR DESCRIPTION
This adds a `robots.txt` file to make sure that web crawlers aren't preventing visualizations from being cleaned up. This may have some negative affects on SEO for the visualization pages, but I think these should be addressed by using a sitemap or similar that  search engine crawlers can use to map the site.