### PR TITLE
Make viz host configurable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,7 @@ services:
       - WEBHOOK_SECRET=${WEBHOOK_SECRET}
       - CS_CRYPT_KEY=${CS_CRYPT_KEY}
       - DEFAULT_CLUSTER_USER=hdoupe
+      - DEFAULT_VIZ_HOST=devviz.compute.studio
     ports:
       - "8000:8000"
     container_name: web

--- a/templates/comp/embed.html
+++ b/templates/comp/embed.html
@@ -30,7 +30,7 @@
       id="embedded-iframe"
       class="embedded"
       title="{{object.title}}"
-      src="{{protocol}}://viz.compute.studio/{{object.owner}}/{{object.title}}/{{deployment.public_name}}/"
+      src="{{protocol}}://{{viz_host}}/{{object.owner}}/{{object.title}}/{{deployment.public_name}}/"
     ></iframe>
     {% else %}
     <div id="notready">
@@ -56,7 +56,7 @@
             container.removeChild(placeholder);
             const iframe = document.createElement("iframe");
             iframe.src =
-              "{{protocol}}://viz.compute.studio/{{object.owner}}/{{object.title}}/{{deployment.public_name}}/";
+              "{{protocol}}://{{viz_host}}/{{object.owner}}/{{object.title}}/{{deployment.public_name}}/";
             iframe.title = "{{object.title}}";
             iframe.className = "embedded";
             iframe.id = "embedded-iframe";

--- a/templates/comp/viz.html
+++ b/templates/comp/viz.html
@@ -29,7 +29,7 @@
 <body class="main" id="iframe-container">
   {% if deployment.status == "running" %}
   <iframe id="embedded-iframe" class="embedded" title="{{object.title}}"
-    src="{{protocol}}://viz.compute.studio/{{object.owner}}/{{object.title}}/{{deployment.public_name}}/"></iframe>
+    src="{{protocol}}://{{viz_host}}/{{object.owner}}/{{object.title}}/{{deployment.public_name}}/"></iframe>
   {% else %}
   <div id="notready">
     <p>Starting the {{object.owner}}/{{object.title}} visualization...</p>
@@ -57,7 +57,7 @@
           container.removeChild(placeholder);
           const iframe = document.createElement("iframe");
           iframe.src =
-            "{{protocol}}://viz.compute.studio/{{object.owner}}/{{object.title}}/{{deployment.public_name}}/";
+            "{{protocol}}://{{viz_host}}/{{object.owner}}/{{object.title}}/{{deployment.public_name}}/";
           iframe.title = "{{object.title}}";
           iframe.className = "embedded";
           iframe.id = "embedded-iframe";

--- a/webapp/apps/comp/views/views.py
+++ b/webapp/apps/comp/views/views.py
@@ -28,7 +28,7 @@ from rest_framework import status
 import fsspec as fs
 import cs_storage
 
-from webapp.settings import DEBUG
+from webapp.settings import DEBUG, DEFAULT_VIZ_HOST
 
 from webapp.apps.billing.models import SubscriptionItem, UsageRecord
 from webapp.apps.billing.utils import has_payment_method
@@ -175,7 +175,7 @@ class VizView(InputsMixin, View):
         context["tech"] = project.tech
         context["object"] = project
         context["deployment"] = deployment
-        context["viz_host"] = os.environ.get("VIZ_HOST")
+        context["viz_host"] = DEFAULT_VIZ_HOST
         context["protocol"] = "https"
         return render(request, self.template_name, context)
 
@@ -201,7 +201,7 @@ class EmbedView(InputsMixin, View):
             "object": project,
             "deployment": deployment,
             "protocol": "https",
-            "viz_host": os.environ.get("VIZ_HOST"),
+            "viz_host": DEFAULT_VIZ_HOST,
         }
         response = render(request, self.template_name, context)
 

--- a/webapp/settings.py
+++ b/webapp/settings.py
@@ -39,6 +39,7 @@ CSRF_COOKIE_NAME = "csrftoken"
 USE_STRIPE = os.environ.get("USE_STRIPE", "false").lower() == "true"
 
 DEFAULT_CLUSTER_USER = os.environ.get("DEFAULT_CLUSTER_USER")
+DEFAULT_VIZ_HOST = os.environ.get("DEFAULT_VIZ_HOST")
 
 # Indicates that this c/s instance uses billing restrictions.
 HAS_USAGE_RESTRICTIONS = (

--- a/workers/cs_workers/cli.py
+++ b/workers/cs_workers/cli.py
@@ -38,7 +38,15 @@ def load_env():
     else:
         user_config = {}
 
-    for var in ["TAG", "PROJECT", "CS_URL", "CS_API_TOKEN", "BUCKET", "CLUSTER_HOST"]:
+    for var in [
+        "TAG",
+        "PROJECT",
+        "CS_URL",
+        "CS_API_TOKEN",
+        "BUCKET",
+        "CLUSTER_HOST",
+        "VIZ_HOST",
+    ]:
         if os.environ.get(var):
             config[var] = os.environ.get(var)
         elif user_config.get(var):
@@ -56,6 +64,7 @@ def cli():
     parser.add_argument(
         "--cs-api-token", required=False, default=config["CS_API_TOKEN"]
     )
+    parser.add_argument("--viz-host", required=False, default=config.get("VIZ_HOST"))
     sub_parsers = parser.add_subparsers()
 
     cs_workers.services.manage.cli(sub_parsers, config=config)

--- a/workers/cs_workers/models/clients/server.py
+++ b/workers/cs_workers/models/clients/server.py
@@ -33,6 +33,7 @@ class Server:
         deployment_name="default",
         namespace="default",
         cr="gcr.io",
+        viz_host=VIZ_HOST,
         incluster=True,
         rclient=None,
         quiet=True,
@@ -46,6 +47,7 @@ class Server:
         self.deployment_name = deployment_name
         self.namespace = namespace
         self.cr = cr
+        self.viz_host = viz_host
         self.quiet = quiet
 
         self.incluster = incluster
@@ -94,7 +96,9 @@ class Server:
             )
 
         envs.append(
-            kclient.V1EnvVar(name="URL_BASE_PATHNAME", value=f"/{owner}/{title}/{deployment_name}/",)
+            kclient.V1EnvVar(
+                name="URL_BASE_PATHNAME", value=f"/{owner}/{title}/{deployment_name}/",
+            )
         )
 
         return envs
@@ -154,7 +158,7 @@ class Server:
         routes = [
             {
                 "kind": "Rule",
-                "match": f"Host(`{VIZ_HOST}`) && PathPrefix(`{path_prefix}`)",
+                "match": f"Host(`{self.viz_host}`) && PathPrefix(`{path_prefix}`)",
                 "services": [{"name": name, "port": 80}],
             }
         ]
@@ -319,5 +323,5 @@ if __name__ == "__main__":
     )
     server
     server.configure()
-    server.apply()
+    server.create()
     # server.delete()

--- a/workers/cs_workers/services/manage.py
+++ b/workers/cs_workers/services/manage.py
@@ -80,6 +80,7 @@ class Manager:
         cs_url=None,
         cs_api_token=None,
         cluster_host=None,
+        viz_host=None,
     ):
         self.tag = tag
         self.project = project
@@ -88,6 +89,7 @@ class Manager:
         self.cs_url = cs_url
         self._cs_api_token = cs_api_token
         self.cluster_host = cluster_host
+        self.viz_host = viz_host
 
         kconfig.load_kube_config()
 
@@ -212,6 +214,9 @@ class Manager:
         deployment["spec"]["template"]["spec"]["containers"][0][
             "image"
         ] = f"gcr.io/{self.project}/scheduler:{self.tag}"
+        deployment["spec"]["template"]["spec"]["containers"][0]["env"].append(
+            {"name": "VIZ_HOST", "value": self.viz_host}
+        )
         self.write_config("scheduler-Deployment.yaml", deployment)
 
         return deployment
@@ -353,6 +358,7 @@ def manager_from_args(args: argparse.Namespace):
         cs_url=getattr(args, "cs_url", None),
         cs_api_token=getattr(args, "cs_api_token", None),
         cluster_host=getattr(args, "cluster_host", None),
+        viz_host=getattr(args, "viz_host", None),
     )
 
 


### PR DESCRIPTION
This PR makes the visualization host configurable. This is helpful for running the dev site with another host like `https://devviz.compute.studio`.

One thing that I noticed while working on this is that Traefik does not seem to work with subdomains that have dots in them. I tried `dev.viz.compute.studio` and get some strange errors about an unfamiliar encryption algorithm.