### PR TITLE
Fix margins

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -188,7 +188,7 @@
         </div>
       </nav>
 
-      <div class="container-fluid mt-4" style="max-width: 1400px">
+      <div class="container-fluid mt-4" style="max-width: 1800px">
         {% block content %} {% endblock %}
       </div>
     </main>

--- a/templates/comp/viz.html
+++ b/templates/comp/viz.html
@@ -23,10 +23,19 @@
       width: 100%;
       border: 0;
     }
+
+    /* From bootstrap. */
+    .container-fluid {
+      width: 100%;
+      padding-right: 15px;
+      padding-left: 15px;
+      margin-right: auto;
+      margin-left: auto;
+    }
   </style>
 </head>
 
-<body class="main" id="iframe-container">
+<body class="main container-fluid" id="iframe-container">
   {% if deployment.status == "running" %}
   <iframe id="embedded-iframe" class="embedded" title="{{object.title}}"
     src="{{protocol}}://{{viz_host}}/{{object.owner}}/{{object.title}}/{{deployment.public_name}}/"></iframe>
@@ -37,7 +46,7 @@
   {% endif %}
   <div style="position: fixed; top: 2rem; right: 2rem;">
     <a href="/{{object.owner}}/{{object.title}}/" style="color:#586069 !important"><i
-        class="fas fa-times fa-lg"></i></a>
+        class="fas fa-times fa-2x"></i></a>
   </div>
 
   <div style="position: fixed; bottom: 1rem; right: 1rem;">


### PR DESCRIPTION
- Updates max width for content on the site to 1800px. This gives the apps a little more real estate on larger screens without making things feel too stretched.
- Uses the bootstrap `container-fluid` class to add a small amount of margin on the sides to the viz page.
- Also makes the 'x' bigger on the viz page to make it easy to get back to the app page on mobile.