### PR TITLE
Pagination fixes

### DIFF
--- a/webapp/apps/publish/views.py
+++ b/webapp/apps/publish/views.py
@@ -20,6 +20,8 @@ from rest_framework.authentication import (
     TokenAuthentication,
 )
 from rest_framework.exceptions import PermissionDenied
+from rest_framework import filters
+
 
 from guardian.shortcuts import assign_perm
 
@@ -368,7 +370,9 @@ class DeploymentsView(generics.ListAPIView):
         BasicAuthentication,
         TokenAuthentication,
     )
-
+    filter_backends = [filters.OrderingFilter]
+    ordering_fields = ["created_at"]
+    ordering = ["created_at"]
     queryset = Deployment.objects.filter(
         deleted_at__isnull=True, status__in=["creating", "running"]
     )

--- a/webapp/settings.py
+++ b/webapp/settings.py
@@ -92,7 +92,7 @@ INSTALLED_APPS = [
 
 REST_FRAMEWORK = {
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
-    "PAGE_SIZE": 50,
+    "PAGE_SIZE": 25,
 }
 
 MIDDLEWARE = [


### PR DESCRIPTION
- Add order to deployments list API view to fix this warning:
    ```
    UnorderedObjectListWarning: Pagination may yield inconsistent results with an unordered object_list: <class 'webapp.apps.users.models.Deployment'> QuerySet.
    ```
- Decrease default page size to improve page load times, especially the sim feed on the home page.