### PR TITLE
Set PYTHONUNBUFFERED to 1 so that Python doesn't buffer logs

### DIFF
--- a/workers/cs_workers/dockerfiles/Dockerfile.model
+++ b/workers/cs_workers/dockerfiles/Dockerfile.model
@@ -4,6 +4,8 @@ FROM continuumio/miniconda3
 USER root
 RUN  apt-get update && apt install libgl1-mesa-glx --yes
 
+ENV PYTHONUNBUFFERED 1
+
 RUN conda config --append channels conda-forge
 RUN conda update conda
 RUN conda install "python>=3.7" pip tornado dask lz4 && pip install boto3 gunicorn


### PR DESCRIPTION
This is helpful for checking in on a running job to make sure that it is making progress. It will also be helpful for #338 once that is set up.