### PR TITLE
[WIP] Add back timeout for sims

### DIFF
--- a/workers/cs_workers/models/clients/job.py
+++ b/workers/cs_workers/models/clients/job.py
@@ -99,6 +99,7 @@ class Job:
             job_id = str(job_id)
 
         config = self.model_config.projects()[f"{owner}/{title}"]
+        timeout = config["expected_task_time"] * 1.25
 
         safeowner = clean(owner)
         safetitle = clean(title)
@@ -106,7 +107,16 @@ class Job:
         container = kclient.V1Container(
             name=job_id,
             image=f"{self.cr}/{self.project}/{safeowner}_{safetitle}_tasks:{tag}",
-            command=["csw", "job", "--job-id", job_id, "--route-name", "sim"],
+            command=[
+                "csw",
+                "job",
+                "--job-id",
+                job_id,
+                "--route-name",
+                "sim",
+                "--timeout",
+                timeout,
+            ],
             env=self.env(owner, title, config),
             resources=kclient.V1ResourceRequirements(**config["resources"]),
         )

--- a/workers/cs_workers/models/executors/api_task.py
+++ b/workers/cs_workers/models/executors/api_task.py
@@ -46,7 +46,9 @@ class Async(tornado.web.RequestHandler):
         if task_id is None:
             task_id = str(uuid.uuid4())
         task_kwargs = payload.get("task_kwargs")
-        async_task = async_task_wrapper(task_id, task_name, handler, task_kwargs)
+        async_task = async_task_wrapper(
+            task_id, task_name, handler, timeout=None, task_kwargs=task_kwargs
+        )
         asyncio.create_task(async_task)
         self.set_status(200)
         self.write({"status": "PENDING", "task_id": task_id})

--- a/workers/cs_workers/models/executors/job.py
+++ b/workers/cs_workers/models/executors/job.py
@@ -39,7 +39,9 @@ routes = {"sim": sim_handler}
 
 def main(args: argparse.Namespace):
     asyncio.run(
-        async_task_wrapper(args.job_id, args.route_name, routes[args.route_name])
+        async_task_wrapper(
+            args.job_id, args.route_name, routes[args.route_name], timeout=args.timeout
+        )
     )
 
 
@@ -47,4 +49,5 @@ def cli(subparsers: argparse._SubParsersAction):
     parser = subparsers.add_parser("job", description="CLI for C/S jobs.")
     parser.add_argument("--job-id", "-t", required=True)
     parser.add_argument("--route-name", "-r", required=True)
+    parser.add_argument("--timeout", required=False, type=int)
     parser.set_defaults(func=main)


### PR DESCRIPTION
- Adds back timeout for simulations.
- Uses `asyncio` instead of Kubernetes's Jobs timeout to more easily cancel the job and send a timeout error back to the webapp.