### PR TITLE
Updates for using GCP's database offering

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - master
       - dev
-      - simplify-publish
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/dev-webapp-deploy.yml
+++ b/.github/workflows/dev-webapp-deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - dev
-      - config-fixes
     paths:
       - "webapp/**"
       - "deploy/**"
@@ -64,7 +63,7 @@ jobs:
       # Setup gcloud CLI
       - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
         with:
-          service_account_email: ${{ secrets.DEV_GKE_EMAIL }}
+          service_account_email: ${{ GKE_EMAIL }}
           service_account_key: ${{ secrets.DEV_GOOGLE_APPLICATION_CREDENTIALS }}
           export_default_credentials: true
 

--- a/.github/workflows/dev-webapp-deploy.yml
+++ b/.github/workflows/dev-webapp-deploy.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - dev
-      - public-private
+      - config-fixes
     paths:
       - "webapp/**"
       - "deploy/**"

--- a/.github/workflows/dev-workers-deploy.yml
+++ b/.github/workflows/dev-workers-deploy.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - dev
-      - public-private
+      - config-fixes
     paths:
       - "workers/**"
       - "deploy/**"

--- a/.github/workflows/webapp-deploy.yml
+++ b/.github/workflows/webapp-deploy.yml
@@ -1,29 +1,33 @@
-name: Dev Workers Deploy
+name: Webapp Deploy
 
 on:
   push:
     branches:
-      - dev
+      - master
     paths:
-      - "workers/**"
+      - "webapp/**"
       - "deploy/**"
-      - ".github/workflows/dev-workers-deploy.yml"
+      - "web-kubernetes/**"
+      - ".github/workflows/webapp-deploy.yml"
+      - "templates/**"
+      - "src/**"
+      - "static/**"
 
 # Environment variables available to all jobs and steps in this workflow
 env:
   GITHUB_SHA: ${{ github.sha }}
 
-  GKE_PROJECT: ${{ secrets.DEV_GKE_PROJECT }}
-  GKE_EMAIL: ${{ secrets.DEV_GKE_EMAIL }}
-  GKE_ZONE: us-central1-c
+  GKE_PROJECT: ${{ secrets.GKE_PROJECT }}
+  GKE_EMAIL: ${{ secrets.GKE_EMAIL }}
+  GKE_ZONE: us-east1-b
   GKE_CLUSTER: cluster-1
   REGISTRY_HOSTNAME: gcr.io
 
-  PROJECT: ${{ secrets.DEV_GKE_PROJECT }}
-  HOST: dev.compute.studio
+  PROJECT: ${{ secrets.GKE_PROJECT }}
+  HOST: compute.studio
   TAG: ${{ github.sha }}
 
-  CS_CONFIG: ${{ secrets.DEV_CS_CONFIG }}
+  CS_CONFIG: ${{ secrets.CS_CONFIG }}
 
 jobs:
   setup-build-publish-deploy:
@@ -38,6 +42,16 @@ jobs:
         with:
           python-version: "3.8"
 
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12'
+      
+      - name: Install yarn 
+        run: npm install yarn 
+      
+      - name: Create app bundle
+        run: yarn install && yarn build
+      
       # Install pip and pytest
       - name: Install dependencies
         run: |
@@ -50,7 +64,7 @@ jobs:
       - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
         with:
           service_account_email: ${{ GKE_EMAIL }}
-          service_account_key: ${{ secrets.DEV_GOOGLE_APPLICATION_CREDENTIALS }}
+          service_account_key: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
           export_default_credentials: true
 
       # Configure docker to use the gcloud command-line tool as a credential helper
@@ -64,15 +78,15 @@ jobs:
 
       - name: Build Docker Images
         run: |
-          cs workers svc build
+          cs webapp build
 
       - name: Push Docker Images
         run: |
-          cs workers svc push
+          cs webapp push
 
       # Apply updates to cluster
       - name: Deploy
         run: |
           gcloud container clusters get-credentials $GKE_CLUSTER --zone $GKE_ZONE --project $GKE_PROJECT
-          cs workers svc config -o - --update-dns | kubectl apply -f -
+          cs webapp config -o - | kubectl apply -f -
           kubectl get pods -o wide

--- a/.github/workflows/workers-deploy.yml
+++ b/.github/workflows/workers-deploy.yml
@@ -3,7 +3,7 @@ name: Dev Workers Deploy
 on:
   push:
     branches:
-      - dev
+      - master
     paths:
       - "workers/**"
       - "deploy/**"
@@ -13,17 +13,17 @@ on:
 env:
   GITHUB_SHA: ${{ github.sha }}
 
-  GKE_PROJECT: ${{ secrets.DEV_GKE_PROJECT }}
-  GKE_EMAIL: ${{ secrets.DEV_GKE_EMAIL }}
-  GKE_ZONE: us-central1-c
+  GKE_PROJECT: ${{ secrets.GKE_PROJECT }}
+  GKE_EMAIL: ${{ secrets.GKE_EMAIL }}
+  GKE_ZONE: us-east1-b
   GKE_CLUSTER: cluster-1
   REGISTRY_HOSTNAME: gcr.io
 
-  PROJECT: ${{ secrets.DEV_GKE_PROJECT }}
-  HOST: dev.compute.studio
+  PROJECT: ${{ secrets.GKE_PROJECT }}
+  HOST: compute.studio
   TAG: ${{ github.sha }}
 
-  CS_CONFIG: ${{ secrets.DEV_CS_CONFIG }}
+  CS_CONFIG: ${{ secrets.CS_CONFIG }}
 
 jobs:
   setup-build-publish-deploy:
@@ -50,7 +50,7 @@ jobs:
       - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
         with:
           service_account_email: ${{ GKE_EMAIL }}
-          service_account_key: ${{ secrets.DEV_GOOGLE_APPLICATION_CREDENTIALS }}
+          service_account_key: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
           export_default_credentials: true
 
       # Configure docker to use the gcloud command-line tool as a credential helper

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ secret.yaml
 *outputs-processor-deployment.yaml
 
 *google-creds.json
-*cs-config.yaml
+*cs-config.*.yaml
 redis-data
 db-data
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ djangorestframework
 msgpack
 requests>=2.20
 requests_mock
-dj_database_url
 dataclasses
 whitenoise
 gunicorn

--- a/web-kubernetes/deployment-cleanup.template.yaml
+++ b/web-kubernetes/deployment-cleanup.template.yaml
@@ -9,16 +9,35 @@ spec:
     spec:
       template:
         spec:
+          serviceAccountName: web
           containers:
             - name: web-deployment-cleanup
               image: # Uses web image and is filled in with script.
               command: ["python", "manage.py", "rm_stale_deployments", "--stale-after", "1800"]
               env:
-                - name: DATABASE_URL
+                - name: DB_HOST
                   valueFrom:
-                    configMapKeyRef:
-                      name: web-configmap
-                      key: DATABASE_URL
+                    secretKeyRef:
+                      name: web-db-secret
+                      key: host
+
+                - name: DB_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: web-db-secret
+                      key: username
+                
+                - name: DB_PASS
+                  valueFrom:
+                    secretKeyRef:
+                      name: web-db-secret
+                      key: password
+                
+                - name: DB_NAME
+                  valueFrom:
+                    secretKeyRef:
+                      name: web-db-secret
+                      key: database
 
                 - name: DEBUG
                   valueFrom:
@@ -57,12 +76,6 @@ spec:
                     secretKeyRef:
                       name: web-secret
                       key: WEB_CS_CRYPT_KEY
-
-                - name: POSTGRES_PASSWORD
-                  valueFrom:
-                    secretKeyRef:
-                      name: web-secret
-                      key: POSTGRES_PASSWORD
 
                 - name: USE_STRIPE
                   valueFrom:

--- a/web-kubernetes/web-configmap.yaml
+++ b/web-kubernetes/web-configmap.yaml
@@ -3,9 +3,8 @@ kind: ConfigMap
 metadata:
   name: web-configmap
 data:
-  DATABASE_URL: "postgresql://db:5432/postgres"
-  BUCKET: cs-outputs-dev-private
-  USE_STRIPE: "false"
-  DEFAULT_CLUSTER_USER: "comp-api-user"
-  DEFAULT_VIZ_HOST: "devviz.compute.studio"
+  DATABASE_URL: ""
+  BUCKET: ""
+  DEFAULT_CLUSTER_USER: ""
+  DEFAULT_VIZ_HOST: ""
   USE_STRIPE: "true"

--- a/web-kubernetes/web-deployment.template.yaml
+++ b/web-kubernetes/web-deployment.template.yaml
@@ -20,10 +20,10 @@ spec:
             - containerPort: 8000
           resources:
             requests:
-              memory: 4G
+              memory: 2G
               cpu: "2"
             limits:
-              memory: 4G
+              memory: 2G
               cpu: "2"
           env:
             - name: PORT

--- a/web-kubernetes/web-deployment.template.yaml
+++ b/web-kubernetes/web-deployment.template.yaml
@@ -12,19 +12,46 @@ spec:
       labels:
         app: web
     spec:
+      serviceAccountName: web
       containers:
         - name: web
           image: web:latest
           ports:
             - containerPort: 8000
+          resources:
+            requests:
+              memory: 4G
+              cpu: "2"
+            limits:
+              memory: 4G
+              cpu: "2"
           env:
             - name: PORT
               value: "8000"
-            - name: DATABASE_URL
+
+            - name: DB_HOST
               valueFrom:
-                configMapKeyRef:
-                  name: web-configmap
-                  key: DATABASE_URL
+                secretKeyRef:
+                  name: web-db-secret
+                  key: host
+
+            - name: DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: web-db-secret
+                  key: username
+            
+            - name: DB_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: web-db-secret
+                  key: password
+            
+            - name: DB_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: web-db-secret
+                  key: database
 
             - name: DEBUG
               valueFrom:
@@ -69,12 +96,6 @@ spec:
                 secretKeyRef:
                   name: web-secret
                   key: WEB_CS_CRYPT_KEY
-
-            - name: POSTGRES_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: web-secret
-                  key: POSTGRES_PASSWORD
 
             - name: USE_STRIPE
               valueFrom:

--- a/web-kubernetes/web-serviceaccount.yaml
+++ b/web-kubernetes/web-serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: web

--- a/webapp/settings.py
+++ b/webapp/settings.py
@@ -143,9 +143,9 @@ WSGI_APPLICATION = "web`app.wsgi.application"
 
 def default_db_url():
     DB_HOST = os.environ.get("DB_HOST", "127.0.0.1")
-    DB_USER = os.environ["DB_USER"]
-    DB_PASS = os.environ["DB_PASS"]
-    DB_NAME = os.environ["DB_NAME"]
+    DB_USER = os.environ.get("DB_USER", "postgres")
+    DB_PASS = os.environ.get("DB_PASS", "")
+    DB_NAME = os.environ.get("DB_NAME", "")
 
     return {
         "ENGINE": "django.db.backends.postgresql",

--- a/webapp/settings.py
+++ b/webapp/settings.py
@@ -11,7 +11,6 @@ https://docs.djangoproject.com/en/2.1/ref/settings/
 """
 from datetime import datetime
 import os
-import dj_database_url
 import pytz
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
@@ -135,7 +134,7 @@ TEMPLATES = [
 
 CRISPY_TEMPLATE_PACK = "bootstrap4"
 
-WSGI_APPLICATION = "webapp.wsgi.application"
+WSGI_APPLICATION = "web`app.wsgi.application"
 
 
 # Database
@@ -143,13 +142,19 @@ WSGI_APPLICATION = "webapp.wsgi.application"
 
 
 def default_db_url():
-    db_config = dj_database_url.config()
-    if os.environ.get("POSTGRES_PASSWORD"):
-        return dict(
-            db_config, USER="postgres", PASSWORD=os.environ.get("POSTGRES_PASSWORD")
-        )
-    else:
-        return db_config
+    DB_HOST = os.environ.get("DB_HOST", "127.0.0.1")
+    DB_USER = os.environ["DB_USER"]
+    DB_PASS = os.environ["DB_PASS"]
+    DB_NAME = os.environ["DB_NAME"]
+
+    return {
+        "ENGINE": "django.db.backends.postgresql",
+        "NAME": DB_NAME,
+        "USER": DB_USER,
+        "PASSWORD": DB_PASS,
+        "HOST": DB_HOST,
+        "PORT": "5432",
+    }
 
 
 DATABASES = {

--- a/workers/cs_workers/dockerfiles/Dockerfile.appbase
+++ b/workers/cs_workers/dockerfiles/Dockerfile.appbase
@@ -9,11 +9,12 @@ RUN conda update conda
 RUN conda install "python>=3.7" pip tornado dask lz4 && pip install boto3 gunicorn
 ARG BRANCH="dev"
 RUN echo ${BRANCH}
-RUN pip install "git+https://github.com/compute-tooling/compute-studio.git@${BRANCH}#egg=cs-workers&subdirectory=workers" \
+RUN pip install \
     cs-kit \ 
     pytest \
-    "git+https://github.com/compute-tooling/compute-studio.git@${BRANCH}#egg=cs-workers&subdirectory=deploy"
+    "git+https://github.com/compute-tooling/compute-studio.git@${BRANCH}#egg=cs-secrets&subdirectory=secrets" \
+    "git+https://github.com/compute-tooling/compute-studio.git@${BRANCH}#egg=cs-deploy&subdirectory=deploy" \
+    "git+https://github.com/compute-tooling/compute-studio.git@${BRANCH}#egg=cs-workers&subdirectory=workers"
 
 
 WORKDIR /home
-

--- a/workers/cs_workers/dockerfiles/Dockerfile.model
+++ b/workers/cs_workers/dockerfiles/Dockerfile.model
@@ -27,8 +27,3 @@ RUN if test -f "./cs-config/setup.py"; then  pip install -e ./cs-config; fi
 EXPOSE 8010
 ENV PORT=8010
 ENV HOST=0.0.0.0
-
-# TODO: Update base image prior to release with these commands.
-ARG BRANCH="dev"
-RUN pip install "git+https://github.com/compute-tooling/compute-studio.git@${BRANCH}#egg=cs-secrets&subdirectory=secrets"
-RUN pip install "git+https://github.com/compute-tooling/compute-studio.git@${BRANCH}#egg=cs-deploy&subdirectory=deploy"

--- a/workers/cs_workers/templates/services/outputs-processor-Deployment.template.yaml
+++ b/workers/cs_workers/templates/services/outputs-processor-Deployment.template.yaml
@@ -12,6 +12,7 @@ spec:
       labels:
         app: outputs-processor
     spec:
+      serviceAccountName: outputs-processor
       containers:
         - name: outputs-processor
           image:

--- a/workers/cs_workers/templates/services/outputs-processor-ServiceAccount.yaml
+++ b/workers/cs_workers/templates/services/outputs-processor-ServiceAccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: outputs-processor


### PR DESCRIPTION
- Updates `cs-config.yaml` format for more flexible storage provider configuration.
- Updates to config generator to pull more information like which GCP project or storage bucket to use from `cs-config.yaml`.

A couple notes:
- The scheduler, web, and outputs-processor deployments now have service accounts that are linked to service accounts on GCP:

```bash
PROJECT=""
WEB_GA=""
SCHED_GA=""
OP_GA=""

# Link webapp service accounts
gcloud iam service-accounts add-iam-policy-binding \
  --role roles/iam.workloadIdentityUser \
  --member "serviceAccount:$PROJECT.svc.id.goog[default/web]" \
  $WEB_GA@$PROJECT.iam.gserviceaccount.com

kubectl annotate serviceaccount \
   web \
   iam.gke.io/gcp-service-account=$WEB_GA@$PROJECT.iam.gserviceaccount.com


# Link scheduler service accounts
gcloud iam service-accounts add-iam-policy-binding \
  --role roles/iam.workloadIdentityUser \
  --member "serviceAccount:$PROJECT.svc.id.goog[default/scheduler]" \
  $SCHED_GA@$PROJECT.iam.gserviceaccount.com

kubectl annotate serviceaccount \
   scheduler \
   iam.gke.io/gcp-service-account=$SCHED_GA@$PROJECT.iam.gserviceaccount.com


# Link outputs-processor service accounts
gcloud iam service-accounts add-iam-policy-binding \
  --role roles/iam.workloadIdentityUser \
  --member "serviceAccount:$PROJECT.svc.id.goog[default/outputs-processor]" \
  $OP_GA@$PROJECT.iam.gserviceaccount.com

kubectl annotate serviceaccount \
   outputs-processor \
   iam.gke.io/gcp-service-account=$OP_GA@$PROJECT.iam.gserviceaccount.com
```

- Database connection information stored separately:

```
kubectl create secret generic web-db-secret \
  --from-literal=username=postgres \
  --from-literal=password=$(cs secrets get POSTGRES_PASSWORD) \
  --from-literal=database=postgres \
  --from-literal=host=127.0.0.1
```