### PR TITLE
Fix cronjob db connection

### DIFF
--- a/.github/workflows/workers-deploy.yml
+++ b/.github/workflows/workers-deploy.yml
@@ -74,5 +74,5 @@ jobs:
       - name: Deploy
         run: |
           gcloud container clusters get-credentials $GKE_CLUSTER --zone $GKE_ZONE --project $GKE_PROJECT
-          cs workers svc config -o - --update-dns --update-redis | kubectl apply -f -
+          cs workers svc config -o - --update-dns | kubectl apply -f -
           kubectl get pods -o wide

--- a/deploy/cs_deploy/webapp.py
+++ b/deploy/cs_deploy/webapp.py
@@ -123,7 +123,11 @@ class Manager:
                       type: Directory
         """
         db_deployment = self.db_deployment
-        db_config = webapp_config["db"]
+        db_config = {}
+        for var in ["db", "web-db"]:
+            db_config = webapp_config.get(var, {})
+            if db_config:
+                break
         assert (
             db_config.get("provider") == "volume"
         ), f"Got: {db_config.get('provider', None)}"
@@ -167,8 +171,14 @@ class Manager:
             web_ir[0]["spec"]["routes"][0]["match"] = f"Host(`{self.host}`)"
             web_ir[1]["spec"]["routes"][0]["match"] = f"Host(`{self.host}`)"
 
-        if webapp_config.get("db", {}).get("provider", "") == "gcp-sql-proxy":
-            spec["containers"].append(webapp_config["db"]["args"][0])
+        db_config = {}
+        for var in ["db", "web-db"]:
+            db_config = webapp_config.get(var, {})
+            if db_config:
+                break
+
+        if db_config.get("provider", "") == "gcp-sql-proxy":
+            spec["containers"].append(db_config["args"][0])
 
         self.write_config(self.web_serviceaccount, filename="web-serviceaccount.yaml")
         self.write_config(web_obj, filename="web-deployment.yaml")
@@ -193,8 +203,14 @@ class Manager:
                     "hostPath": {"path": "/code", "type": "Directory",},
                 }
             ]
-        if webapp_config.get("db", {}).get("provider", "") == "gcp-sql-proxy":
-            spec["containers"].append(webapp_config["db"]["args"][0])
+        db_config = {}
+        for var in ["db", "cronjob-db", "web-db"]:
+            db_config = webapp_config.get(var, {})
+            if db_config:
+                break
+
+        if db_config.get("provider", "") == "gcp-sql-proxy":
+            spec["containers"].append(db_config["args"][0])
 
         self.write_config(job_obj, filename="deployment-cleanup-job.yaml")
 

--- a/web-kubernetes/deployment-cleanup.template.yaml
+++ b/web-kubernetes/deployment-cleanup.template.yaml
@@ -15,6 +15,14 @@ spec:
             - name: web-deployment-cleanup
               image: # Uses web image and is filled in with script.
               command: ["python", "manage.py", "rm_stale_deployments", "--stale-after", "1800"]
+              command: ["/bin/sh", "-c"]
+              args:
+                - |
+                  trap "touch /tmp/pod/main-terminated" EXIT
+                  python manage.py rm_stale_deployments --stale-after 1800
+              volumeMounts:
+                - mountPath: /tmp/pod
+                  name: tmp-pod
               resources:
                 requests:
                   memory: 0.5G
@@ -38,13 +46,13 @@ spec:
                     secretKeyRef:
                       name: web-db-secret
                       key: username
-                
+
                 - name: DB_PASS
                   valueFrom:
                     secretKeyRef:
                       name: web-db-secret
                       key: password
-                
+
                 - name: DB_NAME
                   valueFrom:
                     secretKeyRef:
@@ -132,3 +140,9 @@ spec:
           nodeSelector:
             component: web
           restartPolicy: Never
+          volumes:
+            - name: cloudsql
+              emptyDir: {}
+            - name: tmp-pod
+              emptyDir: {}
+      backoffLimit: 1


### PR DESCRIPTION
The GCP postgres connection is proxied through [`gcp-cloud-proxy` which is run as a sidecar container](https://cloud.google.com/sql/docs/mysql/connect-kubernetes-engine) on the web deployment and cronjobs. The sidecar approach works well for the deployment but it is not shut down by after a job exits. The result is that the container that is actually running the command for the webapp is exiting, but the `gcp-cloud-proxy` sidecar is not.

The [solution](https://github.com/kubernetes/kubernetes/issues/25908#issuecomment-365924958) seems to be to start the proxy and then watch the PID of the main container running the job from the proxy sidecar container. When the main container exits, the sidecar exits afterwards.

Example `cs-config.yaml`:

```yaml
webapp:
  CS_URL: "..."
  PROJECT: "..."
  BUCKET: "..."
  DEFAULT_CLUSTER_USER: "..."
  DEFAULT_VIZ_HOST: "..."

  web-db:
    provider: gcp-sql-proxy
    # https://cloud.google.com/sql/docs/mysql/connect-kubernetes-engine#running_the_proxy_as_a_sidecar
    args:
      - name: cloud-sql-proxy
        image: gcr.io/cloudsql-docker/gce-proxy:1.17
        command:
          - "/cloud_sql_proxy"
          - "-instances=[db-instance-connection]=tcp:5432"
        securityContext:
          runAsNonRoot: true
  cronjob-db:
    provider: gcp-sql-proxy
    args:
      - name: cloudsql-proxy
        image: gcr.io/cloudsql-docker/gce-proxy:1.17
        command: ["/bin/sh", "-c"]
        args:
          - |
            /cloud_sql_proxy --dir=/cloudsql -instances=[db-instance-connection]=tcp:5432 &
            CHILD_PID=$!
            (while true; do if [[ -f "/tmp/pod/main-terminated" ]]; then kill $CHILD_PID; echo "Killed $CHILD_PID as the main container terminated."; fi; sleep 1; done) &
            wait $CHILD_PID
            if [[ -f "/tmp/pod/main-terminated" ]]; then exit 0; echo "Job completed. Exiting..."; fi
        volumeMounts:
          - name: cloudsql
            mountPath: /cloudsql
          - mountPath: /tmp/pod
            name: tmp-pod
            readOnly: true
```