### PR TITLE
Delay starting the deployment cleanup job for 10s while db proxy starts

### DIFF
--- a/web-kubernetes/deployment-cleanup.template.yaml
+++ b/web-kubernetes/deployment-cleanup.template.yaml
@@ -15,9 +15,13 @@ spec:
             - name: web-deployment-cleanup
               image: # Uses web image and is filled in with script.
               command: ["/bin/bash", "-c"]
+              # Creates a main-terminated file on exit.
+              # Sleeps 10 seconds to make sure that the proxy started.
+              # Runs the manage.py command.
               args:
                 - |
                   trap "touch /tmp/pod/main-terminated" EXIT;
+                  sleep 10;
                   python manage.py rm_stale_deployments --stale-after 1800
               volumeMounts:
                 - mountPath: /tmp/pod


### PR DESCRIPTION
The cronjob fix from #366 was failing in the production cluster. I was able to fix it by waiting a few seconds before trying to run the main job. This let the db proxy start before the main container tried to connect to it.