### PR TITLE
Fix auto-upgrade page after trial for user without customer object

### DIFF
--- a/templates/billing/auto_upgrade.html
+++ b/templates/billing/auto_upgrade.html
@@ -55,7 +55,7 @@ information{% endblock %} {% block content %}
           <li class="pt-4">Support the open source development of Compute Studio!</li>
 
         </ul>
-        {% if cancel_at %}
+        {% if cancel_at or not has_payment_info %}
         <div class="text-center">
           <button type="button" class="btn btn-primary text-center" data-toggle="modal" data-target="#proModal">
             <strong>

--- a/webapp/apps/billing/tests/test_views.py
+++ b/webapp/apps/billing/tests/test_views.py
@@ -188,6 +188,23 @@ class TestBillingViews:
         assert next_url == exp_next_url
 
     @pytest.mark.parametrize("plan_duration", ["Monthly", "Yearly"])
+    def test_auto_upgrade_after_trial_no_customer(self, client, plan_duration, profile):
+        """
+        Test auto upgrade after trial page with no customer.
+        """
+        user = User.objects.create_user(
+            f"test-no-cust", f"test-no-cust@example.com", "heyhey2222"
+        )
+        create_profile_from_user(user)
+
+        resp = client.get(f"/billing/upgrade/{plan_duration.lower()}/aftertrial/")
+        assert resp.status_code == 302
+
+        client.force_login(user)
+        resp = client.get(f"/billing/upgrade/{plan_duration.lower()}/aftertrial/")
+        assert resp.status_code == 200
+
+    @pytest.mark.parametrize("plan_duration", ["Monthly", "Yearly"])
     def test_auto_upgrade_after_trial_no_pmt_info(self, client, plan_duration):
         """
         Test opt-in for subscription after trial for user without payment info.

--- a/webapp/apps/billing/tests/test_views.py
+++ b/webapp/apps/billing/tests/test_views.py
@@ -202,7 +202,8 @@ class TestBillingViews:
 
         client.force_login(user)
         resp = client.get(f"/billing/upgrade/{plan_duration.lower()}/aftertrial/")
-        assert resp.status_code == 200
+        assert resp.status_code == 302
+        assert resp.url == f"/billing/upgrade/monthly/"
 
     @pytest.mark.parametrize("plan_duration", ["Monthly", "Yearly"])
     def test_auto_upgrade_after_trial_no_pmt_info(self, client, plan_duration):

--- a/webapp/apps/billing/views.py
+++ b/webapp/apps/billing/views.py
@@ -150,30 +150,29 @@ class AutoUpgradeAfterTrial(View):
         banner_msg = None
         plan_duration = kwargs["plan_duration"]
         customer: Customer = getattr(request.user, "customer", None)
-        _, selected_plan = parse_upgrade_params(request)
+        url_duration, selected_plan = parse_upgrade_params(request)
         next_url = request.GET.get("next", None)
 
         if customer is None:
-            return render(
-                request,
-                self.template_name,
-                context={
-                    "plan_duration": plan_duration,
-                    "current_plan": {"name": "free", "plan_duration": "monthly"},
-                    "card_info": None,
-                    "selected_plan": selected_plan,
-                    "next": next_url,
-                    "banner_msg": banner_msg,
-                    "trial_end": None,
-                    "cancel_at": None,
-                    "has_payment_method": False,
-                },
+            return redirect(
+                reverse(
+                    "upgrade_plan_duration",
+                    kwargs=dict(plan_duration=url_duration or "monthly"),
+                ),
             )
 
         card_info = customer.card_info()
         si = customer.current_plan(as_dict=False)
-        current_plan = customer.current_plan(si=si)
 
+        if si is None:
+            return redirect(
+                reverse(
+                    "upgrade_plan_duration",
+                    kwargs=dict(plan_duration=url_duration or "monthly"),
+                ),
+            )
+
+        current_plan = customer.current_plan(si=si)
         sub: Subscription = si.subscription
         if not sub.is_trial():
             return redirect(

--- a/webapp/apps/billing/views.py
+++ b/webapp/apps/billing/views.py
@@ -150,11 +150,29 @@ class AutoUpgradeAfterTrial(View):
         banner_msg = None
         plan_duration = kwargs["plan_duration"]
         customer: Customer = getattr(request.user, "customer", None)
+        _, selected_plan = parse_upgrade_params(request)
         next_url = request.GET.get("next", None)
+
+        if customer is None:
+            return render(
+                request,
+                self.template_name,
+                context={
+                    "plan_duration": plan_duration,
+                    "current_plan": {"name": "free", "plan_duration": "monthly"},
+                    "card_info": None,
+                    "selected_plan": selected_plan,
+                    "next": next_url,
+                    "banner_msg": banner_msg,
+                    "trial_end": None,
+                    "cancel_at": None,
+                    "has_payment_method": False,
+                },
+            )
+
         card_info = customer.card_info()
         si = customer.current_plan(as_dict=False)
         current_plan = customer.current_plan(si=si)
-        _, selected_plan = parse_upgrade_params(request)
 
         sub: Subscription = si.subscription
         if not sub.is_trial():


### PR DESCRIPTION
- if user has no stripe customer, no subscription or is not on a trial; then redirect to normal plan upgrade page.