### PR TITLE
Worker configuration fixes

### DIFF
--- a/deploy/cs_deploy/config.py
+++ b/deploy/cs_deploy/config.py
@@ -51,6 +51,7 @@ def load_workers_config():
         "CLUSTER_HOST",
         "VIZ_HOST",
         "CS_APPBASE_TAG",
+        "CS_CRYPT_KEY",
     ] | user_config.keys():
         if os.environ.get(var):
             config[var] = os.environ.get(var)

--- a/deploy/cs_deploy/webapp.py
+++ b/deploy/cs_deploy/webapp.py
@@ -228,7 +228,7 @@ class Manager:
             if (val := os.environ.get(var)) is not None:
                 warnings.warn(f"Getting value for {var} from environment.")
                 secret_obj["stringData"][var] = val
-            if (val := secrets.get_or_none(var)) is not None:
+            elif (val := secrets.get_or_none(var)) is not None:
                 secret_obj["stringData"][var] = val
 
         self.write_config(secret_obj, filename="websecret.yaml")

--- a/web-kubernetes/db-deployment.yaml
+++ b/web-kubernetes/db-deployment.yaml
@@ -18,8 +18,8 @@ spec:
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: web-secret
-                  key: POSTGRES_PASSWORD
+                  name: web-db-secret
+                  key: password
           image: postgres:12.4
           ports:
             - containerPort: 5432

--- a/workers/cs_workers/models/manage.py
+++ b/workers/cs_workers/models/manage.py
@@ -493,7 +493,7 @@ class Manager(BaseManager):
         assert (
             resp.status_code == 200
         ), f"Got: {resp.url} {resp.status_code} {resp.text}"
-        return resp.json()["latest_tag"]
+        return resp.json()["latest_tag"]["image_tag"]
 
 
 def build(args: argparse.Namespace):

--- a/workers/cs_workers/services/manage.py
+++ b/workers/cs_workers/services/manage.py
@@ -270,7 +270,9 @@ class Manager:
         secrets = copy.deepcopy(self.secret_template)
         secrets["stringData"]["BUCKET"] = self.bucket
         secrets["stringData"]["PROJECT"] = self.project
-        secrets["stringData"]["CS_CRYPT_KEY"] = self.secrets.get("CS_CRYPT_KEY")
+        secrets["stringData"]["CS_CRYPT_KEY"] = workers_config.get(
+            "CS_CRYPT_KEY"
+        ) or self.secrets.get("CS_CRYPT_KEY")
         redis_secrets = self.redis_secrets()
         for name, sec in redis_secrets.items():
             if sec is not None:

--- a/workers/cs_workers/services/scheduler.py
+++ b/workers/cs_workers/services/scheduler.py
@@ -252,10 +252,21 @@ def get_app():
     config = {}
     for user in all_users():
         print(f"loading data for {user.username} at {user.url}")
-        config[user.username] = ModelConfig(
-            PROJECT, cs_url=user.url, cs_auth_headers=user.headers(), rclient=rclient,
-        )
-        config[user.username].set_projects()
+        try:
+            user_config = ModelConfig(
+                PROJECT,
+                cs_url=user.url,
+                cs_auth_headers=user.headers(),
+                rclient=rclient,
+            )
+            user_config.set_projects()
+            config[user.username] = user_config
+        # Likely to be a network / connection error.
+        except Exception:
+            import traceback
+
+            traceback.print_exc()
+
     print("config?:", config)
     assert rclient.hgetall("projects") is not None
     return tornado.web.Application(

--- a/workers/cs_workers/templates/models/api-task-deployment.template.yaml
+++ b/workers/cs_workers/templates/models/api-task-deployment.template.yaml
@@ -27,10 +27,5 @@ spec:
           env:
             - name: OUTPUTS_VERSION
               value: v1
-            - name: CS_URL
-              valueFrom:
-                secretKeyRef:
-                  name: worker-secret
-                  key: CS_URL
       nodeSelector:
         component: model


### PR DESCRIPTION
- Adds retries with exponential backoff for requests to the CS apps endpoint.
- Grab `CS_CRYPT_KEY` from the environment if it is set.
- Get image tag attribute when using `--uses-latest-tag` flag for deploying a model using the latest tag set on the CS webapp.
- Fix local db configuration to be compatible with GCP proxy changes.
- No longer need to set `CS_URL` in the worker api task template.