### PR TITLE
Fix NS_ERROR_FILE_CORRUPTED error

### DIFF
--- a/src/ParamTools/index.ts
+++ b/src/ParamTools/index.ts
@@ -474,16 +474,30 @@ export function formikToJSON(
 export const Persist = {
   persist: (key: string, values: InitialValues) => {
     console.log("persisting", values);
-    window.localStorage.setItem(key, JSON.stringify(values));
+    try {
+      window.localStorage.setItem(key, JSON.stringify(values));
+    } catch (e) {
+      console.log(e);
+    }
   },
   pop: (key): InitialValues | null => {
-    const data = window.localStorage.getItem(key);
-    Persist.clear(key);
-    if (data) {
-      return (JSON.parse(data) as unknown) as InitialValues;
+    try {
+      const data = window.localStorage.getItem(key);
+      Persist.clear(key);
+      if (data) {
+        return (JSON.parse(data) as unknown) as InitialValues;
+      }
+    } catch (e) {
+      console.log(e);
     }
 
     return null;
   },
-  clear: key => window.localStorage.removeItem(key),
+  clear: key => {
+    try {
+      window.localStorage.removeItem(key);
+    } catch (e) {
+      console.log(e);
+    }
+  },
 };

--- a/src/Simulation/Description.tsx
+++ b/src/Simulation/Description.tsx
@@ -158,18 +158,33 @@ const AuthorsDropDown: React.FC<{ authors: string[] }> = ({ authors }) => {
 // Utility for caching paramtools values in case the user navigates away from the page.
 export const Persist = {
   persist: (key: string, values: DescriptionValues) => {
-    window.localStorage.setItem(key, JSON.stringify(values));
+    try {
+      window.localStorage.setItem(key, JSON.stringify(values));
+    } catch (e) {
+      console.log(e);
+    }
   },
   pop: (key): DescriptionValues | null => {
-    const data = window.localStorage.getItem(key);
-    Persist.clear(key);
-    if (data) {
-      return (JSON.parse(data) as unknown) as DescriptionValues;
+    try {
+      const data = window.localStorage.getItem(key);
+      Persist.clear(key);
+      if (data) {
+        return (JSON.parse(data) as unknown) as DescriptionValues;
+      }
+    } catch (e) {
+      console.log(e);
+      return;
     }
 
     return null;
   },
-  clear: key => window.localStorage.removeItem(key),
+  clear: key => {
+    try {
+      window.localStorage.removeItem(key);
+    } catch (e) {
+      console.log(e);
+    }
+  },
 };
 
 export default class DescriptionComponent extends React.Component<


### PR DESCRIPTION
Handles errors when writing and reading to local storage in a user's browser. It seems like there [isn't much you can do](https://stackoverflow.com/questions/18877643/error-in-local-storage-ns-error-file-corrupted-firefox) when these errors pop up. Most of the time it isn't necessary to use this information. So, this PR just ignores the errors when they pop up.