### PR TITLE
Add opt-in to sub after trial message for private sims

### DIFF
--- a/src/Simulation/modal.tsx
+++ b/src/Simulation/modal.tsx
@@ -245,7 +245,7 @@ const RunDialog: React.FC<{
         {visabilitymsg}
         <>
           <span>
-            Pricing: ${`${accessStatus.exp_cost}`}.
+            Pricing: ${`${accessStatus.exp_cost}`}
             <PricingInfoCollapse accessStatus={accessStatus} />
           </span>
         </>

--- a/src/Simulation/modal.tsx
+++ b/src/Simulation/modal.tsx
@@ -145,7 +145,8 @@ const RunDialog: React.FC<{
   if (accessStatus.sponsor_message) {
     sponsorMessage = accessStatus.sponsor_message;
   }
-  const isPrivateRateLimited = accessStatus.plan.name === "free" && remainingPrivateSims <= 0;
+  const { plan } = accessStatus;
+  const isPrivateRateLimited = plan.name === "free" && remainingPrivateSims <= 0;
   if (isPrivateRateLimited && createsNewSim) {
     isPublic = true;
   } else if (!createsNewSim) {
@@ -185,7 +186,7 @@ const RunDialog: React.FC<{
     );
   }
   let makePrivate;
-  if (accessStatus.plan.name === "free") {
+  if (plan.name === "free") {
     makePrivate = (
       <span>
         Make private ({remainingPrivateSims} remaining this month
@@ -202,6 +203,27 @@ const RunDialog: React.FC<{
     makePrivate = <span>Make private</span>;
   }
 
+  let optInMsg;
+  if (!isPublic && plan.name !== "free" && plan.cancel_at && plan.trial_end) {
+    optInMsg = (
+      <Row className="px-2 pt-2">
+        <Col className="text-center">
+          <div className="alert alert-primary" role="alert">
+            <p>Your free C/S Pro trial ends on {plan.trial_end}.</p>
+            <p>
+              <Button
+                variant="primary"
+                href={`/billing/upgrade/monthly/aftertrial/?next=${window.location.pathname}`}
+              >
+                <strong>Upgrade to C/S Pro after trial</strong>
+              </Button>
+            </p>
+          </div>
+        </Col>
+      </Row>
+    );
+  }
+
   let pricing;
   if (accessStatus.is_sponsored) {
     pricing = (
@@ -212,7 +234,7 @@ const RunDialog: React.FC<{
           {sponsorMessage ? (
             <div dangerouslySetInnerHTML={{ __html: sponsorMessage }} />
           ) : (
-            "anonymous"
+            "an anonymous user."
           )}
         </p>
       </Modal.Body>
@@ -236,6 +258,7 @@ const RunDialog: React.FC<{
       <Modal.Header closeButton>
         <Modal.Title>Create a new {isPublic ? "public" : "private"} simulation</Modal.Title>
       </Modal.Header>
+      {optInMsg}
       {pricing}
       <Modal.Footer style={{ justifyContent: "none" }}>
         <Row className="align-items-center w-100 justify-content-between">

--- a/src/types.ts
+++ b/src/types.ts
@@ -168,7 +168,7 @@ export interface AccessStatus {
   server_cost?: number;
   exp_cost?: number;
   exp_time?: number;
-  plan: { name: "free" | "pro" };
+  plan: { name: "free" | "pro"; cancel_at?: Date | null; trial_end?: Date | null };
   remaining_private_sims: { [project: string]: number };
   project: string;
 }

--- a/webapp/apps/billing/models.py
+++ b/webapp/apps/billing/models.py
@@ -127,6 +127,16 @@ class Customer(models.Model):
             elif si.plan.nickname == "Yearly Pro Plan":
                 current_plan = {"plan_duration": "yearly", "name": "pro"}
 
+            trial_end_date = None
+            cancel_at = None
+            sub = si.subscription
+            if sub.trial_end is not None:
+                trial_end_date = sub.trial_end.date()
+            if sub.cancel_at is not None:
+                cancel_at = sub.cancel_at.date()
+            current_plan["trial_end"] = trial_end_date
+            current_plan["cancel_at"] = cancel_at
+
         except SubscriptionItem.DoesNotExist:
             pass
 

--- a/webapp/apps/billing/views.py
+++ b/webapp/apps/billing/views.py
@@ -152,6 +152,8 @@ class AutoUpgradeAfterTrial(View):
         customer: Customer = getattr(request.user, "customer", None)
         url_duration, selected_plan = parse_upgrade_params(request)
         next_url = request.GET.get("next", None)
+        if next_url is not None:
+            request.session["post_upgrade_url"] = next_url
 
         if customer is None:
             return redirect(
@@ -280,6 +282,9 @@ class AutoUpgradeAfterTrialConfirm(View):
 
         current_si.subscription.update_from_stripe_obj(stripe_sub)
         current_plan = customer.current_plan(si=current_si)
+
+        if request.session.get("post_upgrade_url"):
+            return redirect(request.session.pop("post_upgrade_url"))
 
         banner_msg = (
             f"You will continue to be on the {current_si.plan.nickname} after your trial "

--- a/webapp/apps/users/api.py
+++ b/webapp/apps/users/api.py
@@ -75,6 +75,7 @@ class AccessStatusAPI(GetProjectMixin, APIView):
             username = user.username
             if getattr(user, "customer", None) is not None:
                 plan = user.customer.current_plan()
+
         else:
             user_status = "anon"
             username = None

--- a/webapp/apps/users/api.py
+++ b/webapp/apps/users/api.py
@@ -68,7 +68,12 @@ class AccessStatusAPI(GetProjectMixin, APIView):
 
     def get(self, request, *args, **kwargs):
         user = request.user
-        plan = {"name": "free", "plan_duration": None}
+        plan = {
+            "name": "free",
+            "plan_duration": None,
+            "cancel_at": None,
+            "trial_end": None,
+        }
         remaining_private_sims = {}
         if user.is_authenticated and user.profile:
             user_status = user.profile.status

--- a/webapp/apps/users/tests/test_views.py
+++ b/webapp/apps/users/tests/test_views.py
@@ -216,7 +216,12 @@ class TestUsersViews:
             "server_cost": project.server_cost,
             "api_url": f"/users/status/{project.owner.user.username}/{project.title}/",
             "username": None,
-            "plan": {"name": "free", "plan_duration": None},
+            "plan": {
+                "name": "free",
+                "plan_duration": None,
+                "trial_end": None,
+                "cancel_at": None,
+            },
             "remaining_private_sims": {},
             "project": str(project),
         }
@@ -235,7 +240,12 @@ class TestUsersViews:
             "server_cost": sponsored_project.server_cost,
             "api_url": f"/users/status/{sponsored_project.owner.user.username}/{sponsored_project.title}/",
             "username": None,
-            "plan": {"name": "free", "plan_duration": None},
+            "plan": {
+                "name": "free",
+                "plan_duration": None,
+                "trial_end": None,
+                "cancel_at": None,
+            },
             "remaining_private_sims": {},
             "project": str(sponsored_project),
         }
@@ -246,6 +256,11 @@ class TestUsersViews:
             "user_status": profile.status,
             "api_url": "/users/status/",
             "username": profile.user.username,
-            "plan": {"name": "free", "plan_duration": None},
+            "plan": {
+                "name": "free",
+                "plan_duration": None,
+                "trial_end": None,
+                "cancel_at": None,
+            },
             "remaining_private_sims": {},
         }

--- a/webapp/apps/users/tests/test_views.py
+++ b/webapp/apps/users/tests/test_views.py
@@ -193,7 +193,12 @@ class TestUsersViews:
             "user_status": "anon",
             "api_url": "/users/status/",
             "username": None,
-            "plan": {"name": "free", "plan_duration": None},
+            "plan": {
+                "name": "free",
+                "plan_duration": None,
+                "trial_end": None,
+                "cancel_at": None,
+            },
             "remaining_private_sims": {},
         }
 

--- a/webapp/apps/users/views.py
+++ b/webapp/apps/users/views.py
@@ -61,7 +61,11 @@ class UserSettings(View):
         banner_msg = None
         if getattr(request.user, "customer", None) is not None:
             current_si = request.user.customer.current_plan(as_dict=False)
-            if current_si is not None and current_si.subscription.is_trial():
+            if (
+                current_si is not None
+                and current_si.subscription.is_trial()
+                and current_si.subscription.cancel_at is not None
+            ):
                 banner_msg = mark_safe(
                     f"""
                         <p>Your free C/S Pro trial ends on {current_si.subscription.trial_end.date()}.</p>


### PR DESCRIPTION
Add a banner for users who:
- are on a free trial
- have not opted into an upgrade after the trial
- are running a private simulation

After upgrading, they will be redirected back to the sim page and their input data will still be there.

![image](https://user-images.githubusercontent.com/9206065/106229473-a205cd80-61bb-11eb-8e24-63fb5b89c207.png)
