### PR TITLE
Fix invoice creation logic so that end date is used in query

### DIFF
--- a/webapp/apps/billing/invoice.py
+++ b/webapp/apps/billing/invoice.py
@@ -123,11 +123,15 @@ def create_invoice_items(customer, aggregated_metrics, description, period):
 def invoice_customer(customer, start, end, send_invoice=True):
     profile = customer.user.profile
     owner_sims = process_simulations(
-        profile.sims.filter(sponsor__isnull=True, creation_date__date__gte=start.date())
+        profile.sims.filter(
+            sponsor__isnull=True,
+            creation_date__date__gte=start.date(),
+            creation_date__date__lte=end.date(),
+        )
     )
     sponsor_sims = process_simulations(
         customer.user.profile.sponsored_sims.filter(
-            creation_date__date__gte=start.date()
+            creation_date__date__gte=start.date(), creation_date__date__lte=end.date()
         )
     )
 


### PR DESCRIPTION
This fixes a bug in the invoice creation logic for billing simulations. I forgot to run the invoice command (TODO: this should be run automatically on the first of the month) last week. When I ran it this afternoon, it did not filter out runs after Feb 1. I deleted the invoices while they were still in `draft` status. So no one was affected.