### PR TITLE
Show run modal automatically on redirect back from billing / signup

### DIFF
--- a/src/Simulation/InputsForm.tsx
+++ b/src/Simulation/InputsForm.tsx
@@ -47,6 +47,7 @@ interface InputsFormProps {
   inputs: Inputs;
   defaultURL: string;
   simStatus: Simulation<any>["status"];
+  showRunModal: boolean;
 
   resetInitialValues: (metaParameters: InputsDetail["meta_parameters"]) => void;
   resetting: boolean;
@@ -69,7 +70,7 @@ interface InputsProps {
 }
 
 const InputsForm: React.FC<InputsFormProps & InputsProps> = props => {
-  const [showModal, setShowModal] = React.useState(false);
+  const [showModal, setShowModal] = React.useState(props.showRunModal);
 
   if (!props.inputs || props.resetting) {
     return <LoadingElement />;

--- a/src/Simulation/modal.tsx
+++ b/src/Simulation/modal.tsx
@@ -92,7 +92,10 @@ const RequirePmtDialog: React.FC<{
         <Button
           variant="success"
           onClick={e =>
-            handleCloseWithRedirect(e, `/billing/update/?next=${window.location.pathname}`)
+            handleCloseWithRedirect(
+              e,
+              `/billing/update/?next=${window.location.pathname}?showRunModal=true`
+            )
           }
         >
           <b>Add payment method</b>
@@ -193,7 +196,9 @@ const RunDialog: React.FC<{
         {isPrivateRateLimited && (
           <span>
             .{" "}
-            <a href={`/billing/upgrade/yearly/?next=${window.location.pathname}`}>Upgrade to Pro</a>
+            <a href={`/billing/upgrade/yearly/?next=${window.location.pathname}?showRunModal=true`}>
+              Upgrade to Pro
+            </a>
           </span>
         )}
         )
@@ -213,7 +218,7 @@ const RunDialog: React.FC<{
             <p>
               <Button
                 variant="primary"
-                href={`/billing/upgrade/monthly/aftertrial/?next=${window.location.pathname}`}
+                href={`/billing/upgrade/monthly/aftertrial/?next=${window.location.pathname}?showRunModal=true`}
               >
                 <strong>Upgrade to C/S Pro after trial</strong>
               </Button>


### PR DESCRIPTION
- Automatically show run modal when redirected back to sim page via the `next` parameter.
- Fix polling logic on page load
- Decrease polling interval from 5 to 3 secs