### PR TITLE
Show collaboration modal on page load for home, log, and sim pages

### DIFF
--- a/src/Simulation/Description.tsx
+++ b/src/Simulation/Description.tsx
@@ -28,6 +28,7 @@ interface DescriptionProps {
   remoteSim: Simulation<RemoteOutputs>;
   resetOutputs: () => void;
   resetAccessStatus: () => Promise<AccessStatus>;
+  showCollabModal: boolean;
 }
 
 let Schema = yup.object().shape({
@@ -262,7 +263,6 @@ export default class DescriptionComponent extends React.Component<
   }
 
   pendingPermission() {
-    console.log(this.props.remoteSim?.pending_permissions);
     if (!this.props.remoteSim?.pending_permissions) {
       return undefined;
     }
@@ -426,7 +426,6 @@ export default class DescriptionComponent extends React.Component<
 
     const titleStyle = { display: "inline-block", padding: "5px", margin: 0 };
     const pendingPermission = this.pendingPermission();
-    console.log("pending", pendingPermission);
     return (
       <Formik
         initialValues={this.state.initialValues}
@@ -578,6 +577,7 @@ export default class DescriptionComponent extends React.Component<
                         formikProps={formikProps}
                         accessStatus={this.props.accessStatus}
                         project={`${this.props.api.owner}/${this.props.api.title}`}
+                        initShow={this.props.showCollabModal}
                       />
                     </Col>
                   ) : null}

--- a/src/Simulation/collaborators.tsx
+++ b/src/Simulation/collaborators.tsx
@@ -238,8 +238,9 @@ export const CollaborationSettings: React.FC<{
   formikProps: FormikProps<{ title: string; is_public: boolean } & CollaboratorValues>;
   accessStatus: AccessStatus;
   project: string;
-}> = ({ api, user, remoteSim, formikProps, accessStatus, project }) => {
-  const [show, setShow] = React.useState(false);
+  initShow: boolean;
+}> = ({ api, user, remoteSim, formikProps, accessStatus, project, initShow }) => {
+  const [show, setShow] = React.useState(initShow);
   const is_public =
     remoteSim?.is_public !== undefined ? remoteSim.is_public : formikProps.values.is_public;
   return (
@@ -332,8 +333,8 @@ export const CollaborationModal: React.FC<{
   if (!is_public && plan.name !== "free" && plan.cancel_at && plan.trial_end) {
     const { pathname } = window.location;
     // This modal is shown on the home page and the simulation page.
-    const nextUrl =
-      pathname === "/" || pathname.startsWith("/log") ? pathname : `${pathname}?showRunModal=true`;
+    const showCollabModal = `${api.owner}/${api.title}/${api.modelpk}`;
+    const nextUrl = `${pathname}?showCollabModal=${showCollabModal}`;
     optInMsg = (
       <Row className="px-2 pt-2">
         <Col className="text-center">
@@ -478,7 +479,6 @@ export const CollaborationModal: React.FC<{
                               className="btn btn-outline-secondary lh-1"
                               onClick={e => {
                                 e.preventDefault();
-                                console.log("author set", accessobj.username);
                                 setSelectedUser(accessobj.username);
                                 setTimeout(() => {
                                   setAuthorSelected(true);
@@ -592,7 +592,6 @@ export const CollaborationModal: React.FC<{
                       onSelectUser={selected => {
                         if (remoteSim.access.find(a => a.username === selected.username)) return;
                         setSelectedUser(selected.username);
-                        console.log("access set", selected.username);
                         setTimeout(() => {
                           setAccessSelected(true);
                           setAuthorSelected(false);

--- a/src/Simulation/index.tsx
+++ b/src/Simulation/index.tsx
@@ -15,7 +15,6 @@ import {
   AccessStatus,
   Inputs,
   InitialValues,
-  Schema,
   Simulation,
   RemoteOutputs,
   Outputs,
@@ -63,6 +62,9 @@ interface SimAppState {
   // show run modal on page load.
   showRunModal: boolean;
 
+  // show collaborator modal on page load.
+  showCollabModal: boolean;
+
   // necessary for user id and write access
   accessStatus?: AccessStatus;
 
@@ -103,6 +105,7 @@ class SimTabs extends React.Component<
     this.api = new API(owner, title, modelpk);
     const search = props.location.search;
     const showRunModal = new URLSearchParams(search).get("showRunModal") === "true";
+    const showCollabModal = new URLSearchParams(search).get("showCollabModal") !== null;
     this.state = {
       key: props.tabName,
       hasShownDirtyWarning: false,
@@ -110,6 +113,7 @@ class SimTabs extends React.Component<
       notifyOnCompletion: false,
       isPublic: true,
       showRunModal: showRunModal,
+      showCollabModal: showCollabModal,
     };
 
     this.handleTabChange = this.handleTabChange.bind(this);
@@ -300,7 +304,6 @@ class SimTabs extends React.Component<
     formdata.append("client", "web-beta");
     formdata.append("notify_on_completion", this.state.notifyOnCompletion.toString());
     formdata.append("is_public", this.state.isPublic.toString());
-    console.log("isPublic", this.state.isPublic);
     let url = `/${this.api.owner}/${this.api.title}/api/v1/`;
     let sim = this.state.inputs.detail?.sim;
     const { accessStatus } = this.state;
@@ -494,6 +497,7 @@ class SimTabs extends React.Component<
               this.setState({ accessStatus });
               return accessStatus;
             }}
+            showCollabModal={this.state.showCollabModal}
           />
           <div className="d-flex justify-content-center">
             <ReactLoading type="spokes" color="#2b2c2d" />
@@ -565,6 +569,7 @@ class SimTabs extends React.Component<
                     this.setState({ accessStatus });
                     return accessStatus;
                   }}
+                  showCollabModal={this.state.showCollabModal}
                 />
               </ErrorBoundary>
               <Tab.Container


### PR DESCRIPTION
This builds on #385 and #386 to show the collaboration modal when the page loads instead of the run modal. It also works for the log and home page by using a next url like:

```
/billing/upgrade/monthly/aftertrial/?next=/?showCollabModal=PSLmodels/Tax-Cruncher/352
```

The `showCollabModal` argument is parsed and used to determine which simulation to show the collab modal for.