### PR TITLE
Add social image link to publish ui

### DIFF
--- a/src/Publish/index.tsx
+++ b/src/Publish/index.tsx
@@ -71,6 +71,7 @@ var Schema = yup.object().shape({
   tech: yup.string().required(requiredMessage),
   callable_name: yup.string(),
   is_public: yup.boolean(),
+  social_image_link: yup.string().url(),
 });
 
 export const Message = ({ msg }) => (
@@ -106,6 +107,7 @@ interface ProjectValues {
   tech: Tech | null;
   callable_name: string;
   is_public: boolean;
+  social_image_link: string;
 }
 
 const initialValues: ProjectValues = {
@@ -121,6 +123,7 @@ const initialValues: ProjectValues = {
   tech: null,
   callable_name: "",
   is_public: true,
+  social_image_link: null,
 };
 
 type ProjectSettingsSection = "about" | "configure" | "environment" | "access";
@@ -555,6 +558,32 @@ const AboutAppFields: React.FC<{
         </Field>
       </div>
       {showReadme && <ReadmeField />}
+
+      {showReadme && (
+        <div className="mt-4 mb-2">
+          <label>
+            <strong>Social Image URL</strong>
+            <span className="ml-2">
+              <Tip
+                id="social-image-info"
+                tip="This will be used when sharing your app on social media."
+              >
+                <i className="fas fa-info-circle"></i>
+              </Tip>
+            </span>
+          </label>
+          <Field name="social_image_link">
+            {({ field, meta }) => (
+              <Row className="w-100">
+                <Col>
+                  <input type="url" className="w-100" {...field} />
+                  {meta.touched && meta.error && <div className="text-danger">{meta.error}</div>}
+                </Col>
+              </Row>
+            )}
+          </Field>
+        </div>
+      )}
     </>
   );
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -193,6 +193,7 @@ export interface Project {
   tech?: Tech;
   callable_name?: string;
   app_location?: string;
+  social_image_link?: string;
 }
 
 export interface MiniSimulation {

--- a/webapp/apps/users/serializers.py
+++ b/webapp/apps/users/serializers.py
@@ -38,6 +38,7 @@ class ProjectSerializer(serializers.ModelSerializer):
     repo_tag = serializers.CharField(required=False)
     repo_url = serializers.CharField(required=False)
     is_public = serializers.BooleanField(required=False)
+    social_image_link = serializers.URLField(required=False)
 
     # see to_representation
     # has_write_access = serializers.BooleanField(source="has_write_access")
@@ -87,6 +88,7 @@ class ProjectSerializer(serializers.ModelSerializer):
             "callable_name",
             "tech",
             "is_public",
+            "social_image_link",
         )
         read_only = (
             "sim_count",
@@ -103,6 +105,7 @@ class ProjectWithVersionSerializer(serializers.ModelSerializer):
     user_count = serializers.IntegerField(required=False)
     latest_tag = serializers.StringRelatedField(required=False)
     is_public = serializers.BooleanField(required=False)
+    social_image_link = serializers.URLField(required=False)
 
     # see to_representation
     # has_write_access = serializers.BooleanField(source="has_write_access")
@@ -143,6 +146,7 @@ class ProjectWithVersionSerializer(serializers.ModelSerializer):
             "callable_name",
             "tech",
             "is_public",
+            "social_image_link",
         )
         read_only = ("sim_count", "status", "user_count", "version", "latest_tag")
 


### PR DESCRIPTION
This links the new `social_image_link` field to the publish UI:

![image](https://user-images.githubusercontent.com/9206065/108418809-bb6cc900-71ff-11eb-83fd-ab87452bd86d.png)

In the future, we will host our own images, but this works for a hot fix for now.