### PR TITLE
Backend docker image clean up / streamlining

### DIFF
--- a/workers/cs_workers/dockerfiles/Dockerfile
+++ b/workers/cs_workers/dockerfiles/Dockerfile
@@ -1,9 +1,5 @@
 FROM continuumio/miniconda3
 
-USER root
-RUN  apt-get update && apt install libgl1-mesa-glx --yes
-
-RUN conda update conda
 RUN conda config --append channels conda-forge
 RUN conda install "python>=3.8" pip
 

--- a/workers/cs_workers/dockerfiles/Dockerfile.appbase
+++ b/workers/cs_workers/dockerfiles/Dockerfile.appbase
@@ -1,16 +1,14 @@
 ARG TAG
 FROM continuumio/miniconda3
 
-USER root
 RUN  apt-get update && apt install libgl1-mesa-glx --yes
 
 RUN conda config --append channels conda-forge
-RUN conda update conda
-RUN conda install "python>=3.7" pip tornado dask lz4 && pip install boto3 gunicorn
+RUN conda install "python>=3.7" pip tornado && pip install boto3 gunicorn
 ARG BRANCH="dev"
 RUN echo ${BRANCH}
 RUN pip install \
-    cs-kit \ 
+    "cs-kit>=1.16.2" \
     pytest \
     "git+https://github.com/compute-tooling/compute-studio.git@${BRANCH}#egg=cs-secrets&subdirectory=secrets" \
     "git+https://github.com/compute-tooling/compute-studio.git@${BRANCH}#egg=cs-deploy&subdirectory=deploy" \

--- a/workers/cs_workers/dockerfiles/Dockerfile.model
+++ b/workers/cs_workers/dockerfiles/Dockerfile.model
@@ -13,11 +13,13 @@ ARG REPO_TAG=master
 # Bump to trigger build
 ARG TIME_STAMP=0
 
-RUN git clone -b ${REPO_TAG} ${REPO_URL} 
+RUN git clone -b ${REPO_TAG} ${REPO_URL}
 WORKDIR ${REPO_NAME}
 
-RUN cat ./cs-config/install.sh
-RUN bash ./cs-config/install.sh
+RUN if test -f "./cs-config/install.sh"; then  cat ./cs-config/install.sh; fi
+RUN if test -f "./cs-config/install.sh"; then  bash ./cs-config/install.sh; fi
+
+RUN csk build-env
 RUN if test -f "./cs-config/setup.py"; then  pip install -e ./cs-config; fi
 
 

--- a/workers/cs_workers/dockerfiles/Dockerfile.scheduler
+++ b/workers/cs_workers/dockerfiles/Dockerfile.scheduler
@@ -12,8 +12,7 @@ EXPOSE 80
 EXPOSE 8888
 
 RUN pip install -r requirements.txt
-RUN pip install google-cloud-secret-manager "cs-crypt>=0.0.2" pyjwt
-RUN conda install dask distributed tornado
+RUN conda install tornado
 
 RUN mkdir /home/cs_workers
 COPY workers/cs_workers /home/cs_workers

--- a/workers/cs_workers/services/outputs_processor.py
+++ b/workers/cs_workers/services/outputs_processor.py
@@ -6,7 +6,11 @@ import httpx
 import redis
 import tornado.ioloop
 import tornado.web
-from dask.distributed import Client
+
+try:
+    from dask.distributed import Client
+except ImportError:
+    Client = None
 
 import cs_storage
 
@@ -95,6 +99,7 @@ class Push(tornado.web.RequestHandler):
 
 
 def get_app():
+    assert Client is not None, "Unable to import dask client"
     assert auth.cryptkeeper is not None
     assert BUCKET
     return tornado.web.Application(

--- a/workers/requirements.txt
+++ b/workers/requirements.txt
@@ -6,3 +6,6 @@ boto3
 kubernetes
 cs-storage>=1.11.0
 pyyaml
+google-cloud-secret-manager
+cs-crypt>=0.0.2
+pyjwt

--- a/workers/setup.py
+++ b/workers/setup.py
@@ -25,8 +25,6 @@ setuptools.setup(
         "pyyaml",
         "google-cloud-secret-manager",
         "httpx",
-        "dask",
-        "distributed",
         "tornado",
         "cs-storage>=1.11.0",
         "docker",


### PR DESCRIPTION
- Streamline app install by using `csk build-env` by default
- Remove hard dask dependencies
- Remove 'USER ROOT' usage in docker files 