### PR TITLE
Use django-oauth-toolkit to provide oauth2.0 authentication

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -10,9 +10,8 @@ ADD ./requirements.txt /code/requirements.txt
 ADD ./pytest.ini /code/pytest.ini
 
 # Install dependencies
-RUN conda update conda
-RUN conda install -c conda-forge "python>=3.7.0" pip "paramtools>=0.5.4" "bokeh==1.2.0" gcsfs --yes
-RUN pip install -r requirements.txt
+RUN conda install -c conda-forge "python>=3.7.0" pip "paramtools>=0.5.4" "bokeh==1.2.0" gcsfs --yes && \
+    pip install -r requirements.txt
 
 # Add our code
 COPY ./webapp /code/webapp/

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,5 +20,6 @@ hashids
 django-rest-auth
 django-allauth
 cs-storage>=1.11.0
-cs-crypt>=0.0.1
+cs-crypt>=0.0.2
 pyjwt
+django-oauth-toolkit

--- a/webapp/apps/comp/views/api.py
+++ b/webapp/apps/comp/views/api.py
@@ -20,6 +20,8 @@ from rest_framework.exceptions import PermissionDenied
 from rest_framework.fields import IntegerField
 from rest_framework import filters
 
+from oauth2_provider.contrib.rest_framework import OAuth2Authentication
+
 import paramtools as pt
 import cs_storage
 
@@ -107,6 +109,7 @@ class DetailMyInputsAPIView(APIView):
         SessionAuthentication,
         BasicAuthentication,
         TokenAuthentication,
+        OAuth2Authentication,
     )
 
     queryset = Inputs.objects.all()
@@ -165,6 +168,7 @@ class BaseCreateAPIView(APIView):
         SessionAuthentication,
         BasicAuthentication,
         TokenAuthentication,
+        OAuth2Authentication,
     )
     queryset = Project.objects.all()
 
@@ -202,6 +206,7 @@ class BaseDetailAPIView(GetOutputsObjectMixin, APIView):
         SessionAuthentication,
         BasicAuthentication,
         TokenAuthentication,
+        OAuth2Authentication,
     )
 
     def put(self, request, *args, **kwargs):
@@ -335,6 +340,7 @@ class NewSimulationAPIView(RequiresLoginPermissions, APIView):
         SessionAuthentication,
         BasicAuthentication,
         TokenAuthentication,
+        OAuth2Authentication,
     )
 
     def post(self, request, *args, **kwargs):
@@ -712,6 +718,7 @@ class SimsAPIView(FilterTitle, generics.ListAPIView):
         SessionAuthentication,
         BasicAuthentication,
         TokenAuthentication,
+        OAuth2Authentication,
     )
 
     filter_backends = [filters.OrderingFilter]

--- a/webapp/apps/users/urls.py
+++ b/webapp/apps/users/urls.py
@@ -15,9 +15,11 @@ urlpatterns = [
     path("delete/done/", views.DeleteUserDone.as_view(), name="delete_user_done"),
     path("autocomplete", api.UsersAPIView.as_view(), name="query_users"),
     path("status/", api.AccessStatusAPI.as_view(), name="access_status"),
+    path("me/", api.MeAPI.as_view(), name="me",),
     path(
         "status/<str:username>/<str:title>/",
         api.AccessStatusAPI.as_view(),
         name="access_project",
     ),
+    path("me/<str:username>/<str:title>/", api.MeAPI.as_view(), name="me_project",),
 ]

--- a/webapp/settings.py
+++ b/webapp/settings.py
@@ -94,11 +94,17 @@ INSTALLED_APPS = [
     "allauth.socialaccount",
     "anymail",
     # 'allauth.socialaccount.providers.github', # new
+    "oauth2_provider",
 ]
 
 REST_FRAMEWORK = {
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
     "PAGE_SIZE": 25,
+}
+
+OAUTH2_PROVIDER = {
+    # this is the list of available scopes
+    "SCOPES": {"read": "Read simulations", "write": "Create simulations",}
 }
 
 MIDDLEWARE = [

--- a/webapp/urls.py
+++ b/webapp/urls.py
@@ -65,6 +65,7 @@ urlpatterns = [
         publishviews.RecentModelsAPIView.as_view(),
         name="recent_models_api",
     ),
+    path("o/", include("oauth2_provider.urls", namespace="oauth2_provider")),
     path(
         "<str:username>/<str:title>/",
         publishviews.ProjectDetailView.as_view(),


### PR DESCRIPTION
This makes it possible to build applications on top of Compute Studio and (with users permission) create / read / modify users' data.

I enabled Oauth2 on endpoints for creating / viewing / reading Simulations and a new `/users/me` for retrieving a user's username and project-related roles.

Links:
- `django-oauth-toolkit`: https://django-oauth-toolkit.readthedocs.io/en/latest/
- authorization code oauth flow: https://oauth.net/2/grant-types/authorization-code/