### PR TITLE
Disable subscription cancellation emails

### DIFF
--- a/webapp/apps/billing/models.py
+++ b/webapp/apps/billing/models.py
@@ -185,7 +185,7 @@ class Customer(models.Model):
                     return UpdateStatus.nochange
                 sub.update_from_stripe_obj(stripe_sub)
                 sub.save()
-                send_sub_canceled_email(self.user, sub.current_period_end)
+                # send_sub_canceled_email(self.user, sub.current_period_end)
             else:
                 stripe.SubscriptionItem.modify(
                     current_si.stripe_id, plan=new_plan.stripe_id

--- a/webapp/apps/billing/webhooks.py
+++ b/webapp/apps/billing/webhooks.py
@@ -31,18 +31,23 @@ def customer_subscription_deleted(event):
     sub = get_object_or_404(Subscription, stripe_id=event.data.object.id)
     customer = sub.customer
     sub.delete()
-    print("successfully deleted subscription")
-    send_mail(
-        "Your C/S subscription has been cancelled",
-        (
-            "We are sorry to see you go. If you have a moment, please let us know why "
-            "you have cancelled your subscription and what we can do to win you back "
-            "in the future.\n\nBest,\nThe C/S Team"
-        ),
-        "admin@compute.studio",
-        [customer.user.email],
-        fail_silently=False,
+    print(
+        "successfully deleted subscription",
+        customer.stripe_id,
+        customer.user.email,
+        event.data.object.id,
     )
+    # send_mail(
+    #     "Your C/S subscription has been cancelled",
+    #     (
+    #         "We are sorry to see you go. If you have a moment, please let us know why "
+    #         "you have cancelled your subscription and what we can do to win you back "
+    #         "in the future.\n\nBest,\nThe C/S Team"
+    #     ),
+    #     "admin@compute.studio",
+    #     [customer.user.email],
+    #     fail_silently=False,
+    # )
 
 
 def customer_subscription_updated(event: stripe.Event):


### PR DESCRIPTION
I've gotten a couple of these and am not sure why. Disabling until the batch of trialing users' trial ends.