### PR TITLE
Fix bug in billing upgrade page

### DIFF
--- a/templates/billing/upgrade_plan.html
+++ b/templates/billing/upgrade_plan.html
@@ -174,7 +174,7 @@ information{% endblock %} {% block content %}
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-          {% if not user.customer %}
+          {% if not has_payment_method %}
           <a href="{% url 'update_payment' %}?next=/billing/upgrade/{{plan_duration}}/?selected_plan=pro"
             class="btn btn-primary">Add payment method</a>
           {% else %}


### PR DESCRIPTION
Shows update payment method button if user has no payment method. I missed updating this when attaching customers to users for the trial upgrades in December.

This affected one user.