### PR TITLE
Bump the default number of gunicorn workers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,4 @@ FROM webbase
 
 RUN pip install --upgrade sentry-sdk
 
-CMD gunicorn --bind 0.0.0.0:$PORT webapp.wsgi
+CMD gunicorn --workers 3 --bind 0.0.0.0:$PORT webapp.wsgi


### PR DESCRIPTION
- Update how many gunicorn workers are available. 
- Follows the advice from the gunicorn docs of setting the number of workers to number of cpus (2 for us) + 1. https://docs.gunicorn.org/en/stable/design.html#how-many-workers