### PR TITLE
Dev

### DIFF
--- a/.github/workflows/dev-webapp-deploy.yml
+++ b/.github/workflows/dev-webapp-deploy.yml
@@ -6,6 +6,7 @@ on:
       - dev
     paths:
       - "webapp/**"
+      - "Dockerfile"
       - "deploy/**"
       - "web-kubernetes/**"
       - ".github/workflows/dev-webapp-deploy.yml"

--- a/.github/workflows/webapp-deploy.yml
+++ b/.github/workflows/webapp-deploy.yml
@@ -6,6 +6,7 @@ on:
       - master
     paths:
       - "webapp/**"
+      - "Dockerfile"
       - "deploy/**"
       - "web-kubernetes/**"
       - ".github/workflows/webapp-deploy.yml"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,4 @@ FROM webbase
 
 RUN pip install --upgrade sentry-sdk
 
-CMD gunicorn --bind 0.0.0.0:$PORT webapp.wsgi
+CMD gunicorn --workers 3 --bind 0.0.0.0:$PORT webapp.wsgi


### PR DESCRIPTION
- Increase number of default webapp gunicorn workers to 3 per web replica.
- Update github workflow files to trigger webapp deploy on change to the webapp `Dockerfile`.