### PR TITLE
Use lower memory usage requirements for inputs-related tasks

### DIFF
--- a/workers/cs_workers/services/api/routers/jobs.py
+++ b/workers/cs_workers/services/api/routers/jobs.py
@@ -125,7 +125,15 @@ def create_job(
     db.refresh(instance)
 
     project_data = schemas.Project.from_orm(project).dict()
-    utils.set_resource_requirements(project_data)
+
+    # Use lower memory target for these tasks.
+    if task_name in ("version", "defaults", "parse",):
+        project_data["resources"] = {
+            "requests": {"memory": f"0.25G", "cpu": 0.7},
+            "limits": {"memory": f"0.7G", "cpu": 1},
+        }
+    else:
+        utils.set_resource_requirements(project_data)
 
     if settings.settings.WORKERS_API_HOST:
         url = f"https://{settings.settings.WORKERS_API_HOST}"

--- a/workers/cs_workers/services/api/routers/jobs.py
+++ b/workers/cs_workers/services/api/routers/jobs.py
@@ -129,8 +129,8 @@ def create_job(
     # Use lower memory target for these tasks.
     if task_name in ("version", "defaults", "parse",):
         project_data["resources"] = {
-            "requests": {"memory": f"0.25G", "cpu": 0.7},
-            "limits": {"memory": f"0.7G", "cpu": 1},
+            "requests": {"memory": "0.25G", "cpu": 0.7},
+            "limits": {"memory": "0.7G", "cpu": 1},
         }
     else:
         utils.set_resource_requirements(project_data)


### PR DESCRIPTION
Set lower memory requests and limits for inputs-related jobs. These are the values used for the inputs servers (request 0.25G RAM 0.7 CPU, limit 0.7G RAM 1 CPU). This makes it easier to run more inputs jobs in a single node without having to spin up more servers just to run light-weight tasks.