### PR TITLE
Clean up completed jobs every 3 minutes

### DIFF
--- a/workers/cs-workers/templates/job-cleanup-Job.yaml
+++ b/workers/cs-workers/templates/job-cleanup-Job.yaml
@@ -4,7 +4,7 @@ metadata:
   name: job-cleanup
   namespace: {{ .Values.workers_namespace }}
 spec:
-  schedule: "*/30 * * * *"
+  schedule: "*/3 * * * *"
   successfulJobsHistoryLimit: 0
   jobTemplate:
     spec:


### PR DESCRIPTION
Successfully completed jobs were cleaned up every 30 minutes, but now that more jobs are being spun up, they need to be cleaned up more aggressively. This PR decreases that interval to every 3 minutes. 