### PR TITLE
Add command for migrating a project to a new cluster

### DIFF
--- a/webapp/apps/users/management/commands/migrate_project_cluster.py
+++ b/webapp/apps/users/management/commands/migrate_project_cluster.py
@@ -1,0 +1,33 @@
+"""
+Database updates to migrate project to another cluster.
+"""
+from django.core.management.base import BaseCommand
+
+from webapp.apps.users.models import Project, Cluster
+from webapp.apps.users.serializers import ProjectSerializer
+
+
+class Command(BaseCommand):
+    help = "Migrate project to cluster"
+
+    def add_arguments(self, parser):
+        parser.add_argument("--owner")
+        parser.add_argument("--title")
+        parser.add_argument("--service-account")
+
+    def handle(self, *args, **options):
+        cluster = Cluster.objects.get(
+            service_account__user__username__iexact=options["service_account"]
+        )
+        assert cluster.version == "v1"
+        project = Project.objects.get(
+            owner__user__username__iexact=options["owner"],
+            title__iexact=options["title"],
+        )
+        project.cluster = cluster
+        project.save()
+        project.assign_role("write", cluster.service_account.user)
+
+        Project.objects.sync_project_with_workers(
+            ProjectSerializer(project).data, cluster
+        )


### PR DESCRIPTION
This only updates the database for the webapp and the new cluster. An update like https://github.com/compute-tooling/compute-studio-publish/pull/136 is also required to make sure the new cluster has access to the project's docker image.