### PR TITLE
Temporarily pin pyscopg2 to fix utc connection error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ pytest
 pytest-django
 django-widget-tweaks
 django-crispy-forms
-psycopg2-binary
+psycopg2-binary==2.8.6
 ipython
 markdown
 django-guardian


### PR DESCRIPTION
Fixes:

![image](https://user-images.githubusercontent.com/9206065/122322825-15527680-cef4-11eb-8f99-38ed7b53d996.png)


Related: `https://github.com/psycopg/psycopg2/issues/1293`