### PR TITLE
Set target origin to embed approval url if using iframe resizer

### DIFF
--- a/templates/comp/embed.html
+++ b/templates/comp/embed.html
@@ -60,7 +60,14 @@
     </div>
   </body>
 
-  <script type="text/javascript" src="{% static 'js/vendor/iframeResizer/iframeResizer.min.js' %}"></script>
+{% if object.use_iframe_resizer %}
+<script>
+  window.iFrameResizer = {
+    targetOrigin: "{{embed_approval.url}}"
+  }
+</script>
+{% endif %}
+<script type="text/javascript" src="{% static 'js/vendor/iframeResizer/iframeResizer.min.js' %}"></script>
   <script>
     const checkReady = function() {
       const resp = fetch(

--- a/webapp/apps/comp/views/views.py
+++ b/webapp/apps/comp/views/views.py
@@ -210,6 +210,7 @@ class EmbedView(InputsMixin, View):
 
         context = {
             "object": project,
+            "embed_approval": embed_approval,
             "deployment": deployment,
             "protocol": "https",
             "viz_host": project.cluster.viz_host or DEFAULT_VIZ_HOST,


### PR DESCRIPTION
Uses [target origin](http://davidjbradshaw.github.io/iframe-resizer/#iframe-page-options) setting to fix error from cross domain embed:
![image](https://user-images.githubusercontent.com/9206065/122329882-2c976100-cf00-11eb-998e-35ba62f4f9bf.png)
