### PR TITLE
Fix cors issue by setting address

### DIFF
--- a/workers/cs_workers/models/clients/server.py
+++ b/workers/cs_workers/models/clients/server.py
@@ -125,7 +125,7 @@ class Server:
                 "run",
                 config["app_location"],
                 "--server.address",
-                "0.0.0.0",
+                self.viz_host,
                 "--server.port",
                 str(PORT),
                 "--server.baseUrlPath",


### PR DESCRIPTION
Most sessions don't run into any issues with this but I did notice a cors issue in one of them. This was resolved by refreshing the page, but the documentation seems to indicate that this setting needs to be set to the app domain:

https://docs.streamlit.io/en/stable/streamlit_configuration.html

```
# Internet address where users should point their browsers in order to connect to the app. Can be IP address or DNS name and path.
# This is used to: - Set the correct URL for CORS and XSRF protection purposes. - Show the URL on the terminal - Open the browser - Tell the browser where to connect to the server when in liveSave mode.
# Default: 'localhost'
serverAddress = "localhost"
```