### PR TITLE
Set redis password from an environment variable in redis deployment

### DIFF
--- a/workers/cs-workers/templates/redis-master-Deployment.yaml
+++ b/workers/cs-workers/templates/redis-master-Deployment.yaml
@@ -20,8 +20,8 @@ spec:
         tier: backend
     spec:
       containers:
-        - env: []
-          command: ["redis-server", "--appendonly", "yes"]
+        - command: ["redis-server"]
+          args: ["--appendonly yes", "--requirepass $(REDIS_PASSWORD)"]
           image: redis:6.2.1
           name: master
           ports:
@@ -30,6 +30,12 @@ spec:
             requests:
               cpu: 100m
               memory: 100Mi
+          env:
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: workers-redis-secret
+                  key: PASSWORD
           volumeMounts:
             {{- range $name, $value := .Values.redis.volumeMounts }}
             - name: {{ $value.name }}


### PR DESCRIPTION
Resolves #464. The actual problem is that changes to Redis configurations like the password aren't persisted through the append-only file. This PR sets the redis password using the password in the `workers-redis-secret` secret object.