### PR TITLE
Delete running deployments when a new project version is released

### DIFF
--- a/webapp/apps/publish/views.py
+++ b/webapp/apps/publish/views.py
@@ -320,6 +320,19 @@ class TagsAPIView(GetProjectMixin, APIView):
             )
             project.latest_tag = tag
 
+            for deployment in project.deployments.filter(
+                status__in=["creating", "running"]
+            ):
+                try:
+                    deployment.delete_deployment()
+                except Exception as e:
+                    print(
+                        "Exception when deleting deployment",
+                        deployment.public_name,
+                        project,
+                        e,
+                    )
+
         project.save()
 
         return Response(


### PR DESCRIPTION
Fixes bug where old data-viz deployments are still running when a new tag is created. This bug results in users being sent to the old project version until the deployment is cleaned up by the regular stale deployment cleanup process.