### PR TITLE
Update Dockerfile for apps on C/S

### DIFF
--- a/workers/cs_workers/dockerfiles/Dockerfile.appbase
+++ b/workers/cs_workers/dockerfiles/Dockerfile.appbase
@@ -1,5 +1,5 @@
 ARG TAG
-FROM continuumio/miniconda3
+FROM continuumio/miniconda3:master
 
 RUN  apt-get update && apt install libgl1-mesa-glx --yes
 
@@ -7,9 +7,9 @@ ARG BRANCH="dev"
 RUN echo ${BRANCH}
 
 RUN conda config --append channels conda-forge && \
-    conda install "python>=3.7" pip tornado && \
+    conda install "python>=3.7" pip && \
     pip install gunicorn \
-    "cs-kit>=1.16.2" \
+    "cs-kit>=1.16.9" \
     pytest \
     "git+https://github.com/compute-tooling/compute-studio.git@${BRANCH}#egg=cs-jobs&subdirectory=jobs"
 


### PR DESCRIPTION
- Fixes error with pulling linux updates by using the `continuumio/miniconda3:master` base image.
- Removes unnecessary `tornado` dep since Dask is not used in the c/s cluster any more.
- Bumps `cs-kit` requirement to 1.16.9, which includes `pyyaml` as a dependency.