### PR TITLE
Follow redirects in github api

### DIFF
--- a/workers/cs_workers/cicd/github/api.py
+++ b/workers/cs_workers/cicd/github/api.py
@@ -35,6 +35,7 @@ def get_client(api_token=None):
     return httpx.Client(
         headers={"Authorization": f"token {api_token}"},
         base_url="https://api.github.com",
+        follow_redirects=True,
     )
 
 


### PR DESCRIPTION
`httpx` changed their redirect behavior: https://github.com/encode/httpx/blob/master/CHANGELOG.md#0200-13th-october-2021

![image](https://user-images.githubusercontent.com/9206065/137166293-b41ea5ec-5fc2-4c48-9272-fc1bf7913611.png)
